### PR TITLE
Corrected Solution

### DIFF
--- a/tutorials/learnjavaonline.org/en/Arrays.md
+++ b/tutorials/learnjavaonline.org/en/Arrays.md
@@ -62,7 +62,7 @@ Solution
             int[] numbers = {1, 2, 3};
             int length = numbers[2];
             char[] chars = new char[length];
-            chars[numbers.length] = 'y';
+            chars[numbers.length-1] = 'y';
             System.out.println("Done!");
         }
     }


### PR DESCRIPTION
In the original, it was numbers.length, which would return the number 3, so it was trying to access the fourth spot of the chars[] array, which doesn't exist. Changing this to numbers.length-1 would have it return 2, accessing the third spot which does exist. A simple error it seems but needs to be fixed.
