### PR TITLE
Update Regular Expressions.md

### DIFF
--- a/tutorials/learn-perl.org/Regular Expressions
+++ b/tutorials/learn-perl.org/Regular Expressions
@@ -93,10 +93,10 @@ Parenthesised patterns have a useful property.  When pattern matching is success
 
 	$number = "Telephone:   1234-5678";
 	if ($number =~ m/^Telephone:\s*(\d{4}-\d{4})$/) {
-	  print "The telephone number extracted is "$1"\n";
+	  print "The telephone number extracted is $1\n";
 	}
 	$date = "Date:    2014-jun-01";
-	if ($$date =~ m/^Date:\s*([\d]+)-([a-z]+)-([\d]+)$/) {
+	if ($date =~ m/^Date:\s*([\d]+)-([a-z]+)-([\d]+)$/) {
 	  print "The year is $1, the month is $2, the day is $3\n";
 	}
 


### PR DESCRIPTION
BACKTRACKING example displayed errors as follows:

Scalar found where operator expected at prog.pl line 3, near ""The telephone number extracted is "$1"
	(Missing operator before $1?)
String found where operator expected at prog.pl line 3, near "$1"\n""
	(Missing operator before "\n"?)
syntax error at prog.pl line 3, near ""The telephone number extracted is "$1"
Execution of prog.pl aborted due to compilation errors.

Minor modification and code is now fixed!