### PR TITLE
Fixing title, from generic "Tutorial" to "Closures"

### DIFF
--- a/tutorials/learnpython.org/en/Closures.md
+++ b/tutorials/learnpython.org/en/Closures.md
@@ -1,4 +1,4 @@
-Tutorial
+Closures
 --------
 
 A Closure is a function object that remembers values in enclosing scopes even if they are not present in memory. Let us get to it step by step


### PR DESCRIPTION
The link fro the main page states "Closures", the title in the page generically says "Tutorial", made me wonder if I actually followed the right link :-)