### PR TITLE
Bug fix: resolve the compilation error in Java's Chapter Object.

### DIFF
--- a/tutorials/learnjavaonline.org/en/Objects.md
+++ b/tutorials/learnjavaonline.org/en/Objects.md
@@ -87,7 +87,7 @@ Write a new method in Point called `scale`, that will make the point closer by h
 
 Tutorial Code
 -------------
-public class Point {
+class Point {
     private double x;
     private double y;
     


### PR DESCRIPTION
In the exercise of Java's Chapter Object, the public class were defined
twice, which caused a compilation error.