### PR TITLE
Fixing typos in Markdowns

### DIFF
--- a/tutorials/learnrubyonline.org/en/Methods With Parameters.md
+++ b/tutorials/learnrubyonline.org/en/Methods With Parameters.md
@@ -29,6 +29,7 @@ Tutorial Code
 Expected Output
 ---------------
 4
+
 Solution
 --------
 def square(number)

--- a/tutorials/learnrubyonline.org/en/Methods.md
+++ b/tutorials/learnrubyonline.org/en/Methods.md
@@ -22,6 +22,7 @@ end
 Expected Output
 ---------------
 Hi!
+
 Solution
 --------
 def say_hi


### PR DESCRIPTION
Fixing some typos in both Ruby methods tutorials. It wasn't formatted properly in the Markdown files.