### PR TITLE
golang variables: fix typo in solution output

### DIFF
--- a/tutorials/learn-golang.org/en/Variables.md
+++ b/tutorials/learn-golang.org/en/Variables.md
@@ -96,7 +96,7 @@ Solution
     package main
     import "fmt"
     func main() {
-        name := "Jhon Doe"
+        name := "John Doe"
         age := 24
         weigth := 154.61
         fmt.Println(name)


### PR DESCRIPTION
The suggested solution did not pass the expected output verification
due to a typo.