### PR TITLE
Added link to Exceptions

### DIFF
--- a/tutorials/learn-php.org/en/Welcome.md
+++ b/tutorials/learn-php.org/en/Welcome.md
@@ -21,6 +21,7 @@ There is no need to download anything - just click on the chapter you wish to be
 - [[While loops]]
 - [[Functions]]
 - [[Objects]]
+- [[Exceptions]]
 
 ### Contributing Tutorials
 


### PR DESCRIPTION
Long time ago I've created Exceptions tutorial, but it looks like its unaccessible from main page and doesn't appears at the Main page.