### PR TITLE
Reformat and Improve PHP Exceptions tutorial

### DIFF
--- a/tutorials/learn-php.org/en/Exceptions.md
+++ b/tutorials/learn-php.org/en/Exceptions.md
@@ -4,55 +4,65 @@ PHP has an exception model similar to that of other programming languages.
 An exception can be thrown, and caught ("catched") within PHP.
 Code may be surrounded in a try block, to facilitate the catching of potential exceptions.
 Each try must have at least one corresponding catch or finally block.
-```php
-try {
-echo 2 / 0;
-} catch (Exception $e) {
-echo "Caught exception: Division by zero!";
-}
-```
+
+    try {
+      echo 2 / 0;
+    } catch (Exception $e) {
+      echo "Caught exception: Division by zero!";
+    }
+
 Multiple catch blocks can be used to catch different classes of exceptions.
 Normal execution (when no exception is thrown within the try block) will continue after
 that last catch block defined in sequence. Exceptions can be thrown (or re-thrown) within a catch block.
-```php
-if (4/2 == 2) {
-echo "Right!";
-} else {
-throw new Exception("Wrong answer!");
-}
-```
+
+    if (4/2 == 2) {
+      echo "Right!";
+    } else {
+      throw new Exception("Wrong answer!");
+    }
+
 When an exception is thrown, code following the statement will not be executed,
 and PHP will attempt to find the first matching catch block. If an exception is not caught,
 a PHP Fatal Error will be issued with an "Uncaught Exception ..." message,
 unless a handler has been defined with set_exception_handler().
+
+## Finally Blocks
+
 In PHP 5.5 and later, a finally block may also be specified after or instead of catch blocks.
-Code within the finally block will always be executed after the try and catch blocks,
+Code within the finally block will **always be executed** after the try and catch blocks,
 regardless of whether an exception has been thrown, and before normal execution resumes.
-```php
-try {
-echo 4/0;
-} catch (Exception $e) {
-echo "Divided by zero!";
-} finally {
-echo "This will be outputed even if exception will happen!";
-}
-```
+
+    try {
+      echo 4/0;
+    } catch (Exception $e) {
+      echo "Divided by zero!";
+    } finally {
+      echo "This will be outputed even if exception will happen!";
+    }
+
 
 Exercise
 --------
-Learn how to cope with exceptions, by trying to fill the right words:
+Use a try-catch-finally block to first catch the exception and print out `Exception caught!` and then finally print out `Done!`.
+Your final output should look like:
+```
+Exception caught!
+Done!
+```
 
 Tutorial Code
 -------------
-```php
-try {
-echo 10/(1-1);
-} _____ (Exception __) {
-echo "Exception caught!";
-} final__ {
-echo "Done!"_
+
+<?php
+# This function will throw an exception!
+function throw_exception() {
+  throw new Exception("Exception!");
 }
-```
+
+# Surround the statement in a try-catch-finally block!
+throw_exception();
+?>
+
 
 Expected Output
 ---------------
@@ -61,12 +71,18 @@ Done!
 
 Solution
 --------
-```php
-try {
-echo 10/(1-1);
-} catch (Exception $e) {
-echo "Exception caught!";
-} finally {
-echo "Done!";
+<?php
+# This function will throw an exception!
+function throw_exception() {
+  throw new Exception("Exception!");
 }
-```
+
+# Surround the statement in a try-catch-finally block!
+try {
+  throw_exception();
+} catch (Exception $e) {
+  echo "Exception caught!\n";
+} finally {
+  echo "Done!";
+}
+?>


### PR DESCRIPTION
Previously the format was geared towards markdown which did not transfer properly over to the site.
These changes fix the the format as well as improve the tutorial code.

The old tutorial code used an example of division by a zero, however the online php compiler does not throw a catchable exception for division by zero, it throws a warning. 