### PR TITLE
C - Require code changes to pass Dynamic Allocation Tutorial

### DIFF
--- a/tutorials/learn-c.org/de/Dynamic allocation.md
+++ b/tutorials/learn-c.org/de/Dynamic allocation.md
@@ -49,7 +49,7 @@ Tutorial Code
     } point;
 
     int main() {
-      point * mypoint;
+      point * mypoint = NULL;
 
       /* Belege ein neues point Strukt hier,
          sodass mypoint darauf zeigt */

--- a/tutorials/learn-c.org/en/Dynamic allocation.md
+++ b/tutorials/learn-c.org/en/Dynamic allocation.md
@@ -48,7 +48,7 @@ Tutorial Code
     } point;
 
     int main() {
-      point * mypoint;
+      point * mypoint = NULL;
 
       /* Dynamically allocate a new point
          struct which mypoint points to here */

--- a/tutorials/learn-c.org/nl/Dynamic allocation.md
+++ b/tutorials/learn-c.org/nl/Dynamic allocation.md
@@ -48,7 +48,7 @@ Tutorial Code
     } point;
 
     int main() {
-      point * mypoint;
+      point * mypoint = NULL;
 
       /* Dynamically allocate a new point
          struct which mypoint points to here */


### PR DESCRIPTION
Currently the Dynamic allocation tutorial requires no changes to pass. It will include warnings:
```
 malloc: *** error for object 0x7ffee039e910: pointer being freed was not allocated
 malloc: *** set a breakpoint in malloc_error_break to debug
 ```
 But still pass.

 Setting the pointer specifically to `NULL` requires code changes to make the exercise pass, as it prints nothing by default now.