### PR TITLE
cast malloc return

### DIFF
--- a/tutorials/learn-c.org/en/Dynamic allocation.md
+++ b/tutorials/learn-c.org/en/Dynamic allocation.md
@@ -14,7 +14,7 @@ Let's assume we want to dynamically allocate a person structure. The person is d
 
 To allocate a new person in the `myperson` argument, we use the following syntax:
 
-    person * myperson = malloc(sizeof(person));
+    person * myperson = (person *) malloc(sizeof(person));
 
 This tells the compiler that we want to dynamically allocate just enough to hold a person struct in memory, and then return a pointer to the newly allocated data.
 


### PR DESCRIPTION
To match solution after 3b26a7564051bc0c196327cd2f15a897b062e8c5, should the tutorial itself also cast the `malloc` return value?

I was confused by the error returned when not casting `malloc`'s return value, despite using the exact same code as in the accompanying text.

```c
prog.cpp: In function ‘int main()’:
prog.cpp:12:27: error: invalid conversion from ‘void*’ to ‘point*’ [-fpermissive]
   point * mypoint = malloc(sizeof(point));
                     ~~~~~~^~~~~~~~~~~~~~~

```