### PR TITLE
Update Manupulating Arrays.md; fixed a mismatch

### DIFF
--- a/tutorials/learn-js.org/en/Manipulating Arrays.md
+++ b/tutorials/learn-js.org/en/Manipulating Arrays.md
@@ -29,7 +29,7 @@ This will print out the variable we popped from the array, and what's left of th
 
 ### Queues using shifting and unshifting
 
-The `shift` and `unshift` methods are similar to `push` and `pop`, only they work from the beginning of the array. We can use the `push` and `shift` methods consecutively to utilize an array as a queue. For example:
+The `unshift` and `shift` methods are similar to `push` and `pop`, only they work from the beginning of the array. We can use the `push` and `shift` methods consecutively to utilize an array as a queue. For example:
 
     var myQueue = [];
     myQueue.push(1);


### PR DESCRIPTION
So while learning JS I found this mistake.
`shift` removes element, so is similar to `pop`.
`unshift` adds element, so is similar to `push`.
Hence the proper wordings should be : *The `unshift` and `shift` methods are similar to `push` and `pop`* instead of *The `shift` and `unshift` methods are similar to `push` and `pop`*.