### PR TITLE
Update Basic Elements.md, removed ambiguity of hr tags.

### DIFF
--- a/tutorials/learn-html.org/en/Basic Elements.md
+++ b/tutorials/learn-html.org/en/Basic Elements.md
@@ -56,7 +56,7 @@ A horizontal ruler `<hr>` tag acts as a simple separator between page sections.
         <body>
             <h1>My First Page</h1>
             <p>This is my first page.</p>
-            <hr/>
+            <hr>
             <p>This is the footer - all rights are reserved to me.</p>
         </body>
     </html>


### PR DESCRIPTION
In the *horizontal ruler* section, the demo code snippet uses `<hr/>` instead of `<hr>`. Though it doesn't affect the output, it confuses newbies, like *why a `/`? Is it part of syntax?*