### PR TITLE
addtl clarity in exercise Functions (c tutorial)

### DIFF
--- a/tutorials/learn-c.org/en/Functions.md
+++ b/tutorials/learn-c.org/en/Functions.md
@@ -56,7 +56,7 @@ We can also create functions that do not return a value by using the keyword `vo
 Exercise
 --------
 
-Write a function called `print_big` which receives one argument (an integer) and prints the line `x is big` if the argument given
+Write a function called `print_big` which receives one argument (an integer) and prints the line `x is big` (where x is the argument) if the argument given
 to the function is a number bigger than 10. 
 
 * **Important**: Don't forget to add a newline character `\n` at the end of the printf string.


### PR DESCRIPTION
Tweaked exercise instructions to clarify not to literally print "x is big" but rather clarify x is the function argument