### PR TITLE
Fix typo in Methods.md

### DIFF
--- a/tutorials/learncs.org/en/Methods.md
+++ b/tutorials/learncs.org/en/Methods.md
@@ -85,12 +85,12 @@ Tutorial Code
 
             int x = 2;
             int y = 2;
-            int a = foo(x,y);
+            int a = Foo(x,y);
             Console.WriteLine(a);
 
         }
 
-        //write method foo here
+        //write method Foo here
     }
 
 Expected Output


### PR DESCRIPTION
Changed typo in method name in the exercise. It was typed as "foo" but should be "Foo" since method names in C# should start with capital letters. The solution code already had the right capitalization