### PR TITLE
Replaced suds with suds-py3

### DIFF
--- a/suds/__init__.py
+++ b/suds/__init__.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,36 +19,40 @@ Suds is a lightweight SOAP python client that provides a
 service proxy for Web Services.
 """
 
-import os
-import sys
+from .compat import basestring, unicode
 
 #
 # Project properties
 #
 
-__version__ = '0.4'
-__build__="GA R699-20100913"
+__version__ = '1.4.4.1'
+__build__ = "IN 20210108"
 
 #
 # Exceptions
 #
 
+
 class MethodNotFound(Exception):
     def __init__(self, name):
         Exception.__init__(self, "Method not found: '%s'" % name)
-        
+
+
 class PortNotFound(Exception):
     def __init__(self, name):
         Exception.__init__(self, "Port not found: '%s'" % name)
-        
+
+
 class ServiceNotFound(Exception):
     def __init__(self, name):
         Exception.__init__(self, "Service not found: '%s'" % name)
-    
+
+
 class TypeNotFound(Exception):
     def __init__(self, name):
         Exception.__init__(self, "Type not found: '%s'" % tostr(name))
-    
+
+
 class BuildError(Exception):
     msg = \
         """
@@ -58,9 +62,11 @@ class BuildError(Exception):
         Please open a ticket with a description of this error.
         Reason: %s
         """
+
     def __init__(self, name, exception):
         Exception.__init__(self, BuildError.msg % (name, exception))
-        
+
+
 class SoapHeadersNotPermitted(Exception):
     msg = \
         """
@@ -68,13 +74,41 @@ class SoapHeadersNotPermitted(Exception):
         define SOAP headers for this method.  Retry without the soapheaders
         keyword argument.
         """
+
     def __init__(self, name):
         Exception.__init__(self, self.msg % name)
-    
+
+
+def smart_str(s, encoding='utf-8', errors='strict'):
+    """
+    Returns a bytestring version of 's', encoded as specified in 'encoding'.
+
+    If strings_only is True, don't convert (some) non-string-like objects.
+
+    from django
+    """
+    if not isinstance(s, basestring):
+        try:
+            return str(s)
+        except UnicodeEncodeError:
+            if isinstance(s, Exception):
+                # An Exception subclass containing non-ASCII data that doesn't
+                # know how to print itself properly. We shouldn't raise a
+                # further exception.
+                return ' '.join(smart_str(arg, encoding, errors) for arg in s)
+            return unicode(s).encode(encoding, errors)
+    elif isinstance(s, unicode):
+        return s.encode(encoding, errors)
+    elif s and encoding != 'utf-8':
+        return s.decode('utf-8', errors).encode(encoding, errors)
+    else:
+        return s
+
+
 class WebFault(Exception):
     def __init__(self, fault, document):
         if hasattr(fault, 'faultstring'):
-            Exception.__init__(self, "Server raised fault: '%s'" % fault.faultstring)
+            Exception.__init__(self, smart_str("Server raised fault: '%s'" % fault.faultstring))
         self.fault = fault
         self.document = document
 
@@ -82,19 +116,22 @@ class WebFault(Exception):
 # Logging
 #
 
+
 class Repr:
     def __init__(self, x):
         self.x = x
+
     def __str__(self):
-        return repr(self.x)  
+        return repr(self.x)
 
 #
 # Utility
 #
 
+
 def tostr(object, encoding=None):
     """ get a unicode safe string representation of an object """
-    if isinstance(object, str):
+    if isinstance(object, basestring):
         if encoding is None:
             return object
         else:
@@ -102,7 +139,7 @@ def tostr(object, encoding=None):
     if isinstance(object, tuple):
         s = ['(']
         for item in object:
-            if isinstance(item, str):
+            if isinstance(item, basestring):
                 s.append(item)
             else:
                 s.append(tostr(item))
@@ -112,7 +149,7 @@ def tostr(object, encoding=None):
     if isinstance(object, list):
         s = ['[']
         for item in object:
-            if isinstance(item, str):
+            if isinstance(item, basestring):
                 s.append(item)
             else:
                 s.append(tostr(item))
@@ -121,13 +158,13 @@ def tostr(object, encoding=None):
         return ''.join(s)
     if isinstance(object, dict):
         s = ['{']
-        for item in list(object.items()):
-            if isinstance(item[0], str):
+        for item in object.items():
+            if isinstance(item[0], basestring):
                 s.append(item[0])
             else:
                 s.append(tostr(item[0]))
             s.append(' = ')
-            if isinstance(item[1], str):
+            if isinstance(item[1], basestring):
                 s.append(item[1])
             else:
                 s.append(tostr(item[1]))
@@ -135,20 +172,26 @@ def tostr(object, encoding=None):
         s.append('}')
         return ''.join(s)
     try:
-        return str(object)
+        return unicode(object)
     except:
         return str(object)
-    
+
+
 class null:
     """
     The I{null} object.
     Used to pass NULL for optional XML nodes.
     """
     pass
-    
+
+class Object(object):
+    """
+    The python 3 base Object
+    """
+    pass
+
 def objid(obj):
-    return obj.__class__.__name__\
-        +':'+hex(id(obj))
+    return obj.__class__.__name__ + ':' + hex(id(obj))
 
 
-from . import client
+from .client import Client

--- a/suds/bindings/__init__.py
+++ b/suds/bindings/__init__.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,

--- a/suds/bindings/document.py
+++ b/suds/bindings/document.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,7 +19,6 @@ Provides classes for the (WS) SOAP I{document/literal}.
 """
 
 from logging import getLogger
-from suds import *
 from suds.bindings.binding import Binding
 from suds.sax.element import Element
 
@@ -32,12 +31,14 @@ class Document(Binding):
     since document/encoded is pretty much dead.
     Although the soap specification supports multiple documents within the soap
     <body/>, it is very uncommon.  As such, suds presents an I{RPC} view of
-    service methods defined with a single document parameter.  This is done so 
-    that the user can pass individual parameters instead of one, single document.
-    To support the complete specification, service methods defined with multiple documents
-    (multiple message parts), must present a I{document} view for that method.
+    service methods defined with a single document parameter.  This is done so
+    that the user can pass individual parameters instead of one, single
+    document.
+    To support the complete specification, service methods defined withs
+    multiple documents (multiple message parts), must present a I{document}
+    view for that method.
     """
-        
+
     def bodycontent(self, method, args, kwargs):
         #
         # The I{wrapped} vs I{bare} style is detected in 2 ways.
@@ -75,7 +76,7 @@ class Document(Binding):
             return body[0].children
         else:
             return body.children
-        
+
     def document(self, wrapper):
         """
         Get the document root.  For I{document/literal}, this is the
@@ -89,7 +90,7 @@ class Document(Binding):
         ns = wrapper[1].namespace('ns0')
         d = Element(tag, ns=ns)
         return d
-    
+
     def mkparam(self, method, pdef, object):
         #
         # Expand list parameters into individual parameters
@@ -103,7 +104,7 @@ class Document(Binding):
             return tags
         else:
             return Binding.mkparam(self, method, pdef, object)
-        
+
     def param_defs(self, method):
         #
         # Get parameter definitions for document literal.
@@ -124,14 +125,13 @@ class Document(Binding):
                 if child.isattr():
                     continue
                 if self.bychoice(ancestry):
-                    log.debug(
-                        '%s\ncontained by <choice/>, excluded as param for %s()',
-                        child,
-                        method.name)
+                    log.debug('%s\ncontained by <choice/>, excluded as param for %s()',
+                              child,
+                              method.name)
                     continue
                 result.append((child.name, child))
         return result
-    
+
     def returned_types(self, method):
         result = []
         wrapped = method.soap.output.body.wrapped
@@ -145,7 +145,7 @@ class Document(Binding):
         else:
             result += rts
         return result
-    
+
     def bychoice(self, ancestry):
         """
         The ancestry contains a <choice/>

--- a/suds/bindings/multiref.py
+++ b/suds/bindings/multiref.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,12 +19,11 @@ Provides classes for handling soap multirefs.
 """
 
 from logging import getLogger
-from suds import *
-from suds.sax.element import Element
 
 log = getLogger(__name__)
 
 soapenc = (None, 'http://schemas.xmlsoap.org/soap/encoding/')
+
 
 class MultiRef:
     """
@@ -32,13 +31,13 @@ class MultiRef:
     @ivar nodes: A list of non-multiref nodes.
     @type nodes: list
     @ivar catalog: A dictionary of multiref nodes by id.
-    @type catalog: dict 
+    @type catalog: dict
     """
-    
+
     def __init__(self):
         self.nodes = []
         self.catalog = {}
-    
+
     def process(self, body):
         """
         Process the specified soap envelope body and replace I{multiref} node
@@ -54,11 +53,12 @@ class MultiRef:
         self.update(body)
         body.children = self.nodes
         return body
-    
+
     def update(self, node):
         """
-        Update the specified I{node} by replacing the I{multiref} references with
-        the contents of the referenced nodes and remove the I{href} attribute.
+        Update the specified I{node} by replacing the I{multiref} references
+        with the contents of the referenced nodes and remove the I{href}
+        attribute.
         @param node: A node to update.
         @type node: L{Element}
         @return: The updated node
@@ -68,12 +68,12 @@ class MultiRef:
         for c in node.children:
             self.update(c)
         return node
-            
+
     def replace_references(self, node):
         """
-        Replacing the I{multiref} references with the contents of the 
+        Replacing the I{multiref} references with the contents of the
         referenced nodes and remove the I{href} attribute.  Warning:  since
-        the I{ref} is not cloned, 
+        the I{ref} is not cloned,
         @param node: A node to update.
         @type node: L{Element}
         """
@@ -91,7 +91,7 @@ class MultiRef:
             if a.name != 'id':
                 node.append(a)
         node.remove(href)
-            
+
     def build_catalog(self, body):
         """
         Create the I{catalog} of multiref nodes by id and the list of
@@ -103,9 +103,11 @@ class MultiRef:
             if self.soaproot(child):
                 self.nodes.append(child)
             id = child.get('id')
-            if id is None: continue
-            key = '#%s' % id
-            self.catalog[key] = child
+            if id is None:
+                self.build_catalog(child)
+            else:                
+                key = '#%s' % id
+                self.catalog[key] = child
 
     def soaproot(self, node):
         """
@@ -122,5 +124,4 @@ class MultiRef:
         if root is None:
             return True
         else:
-            return ( root.value == '1' )
-        
+            return root.value == '1'

--- a/suds/bindings/rpc.py
+++ b/suds/bindings/rpc.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,7 +19,6 @@ Provides classes for the (WS) SOAP I{rpc/literal} and I{rpc/encoded} bindings.
 """
 
 from logging import getLogger
-from suds import *
 from suds.mx.encoded import Encoded as MxEncoded
 from suds.umx.encoded import Encoded as UmxEncoded
 from suds.bindings.binding import Binding, envns
@@ -30,21 +29,22 @@ log = getLogger(__name__)
 
 encns = ('SOAP-ENC', 'http://schemas.xmlsoap.org/soap/encoding/')
 
+
 class RPC(Binding):
     """
     RPC/Literal binding style.
     """
-    
+
     def param_defs(self, method):
         return self.bodypart_types(method)
-        
+
     def envelope(self, header, body):
         env = Binding.envelope(self, header, body)
         env.addPrefix(encns[0], encns[1])
-        env.set('%s:encodingStyle' % envns[0], 
+        env.set('%s:encodingStyle' % envns[0],
                 'http://schemas.xmlsoap.org/soap/encoding/')
         return env
-        
+
     def bodycontent(self, method, args, kwargs):
         n = 0
         root = self.method(method)
@@ -58,10 +58,10 @@ class RPC(Binding):
                 root.append(p)
             n += 1
         return root
-    
+
     def replycontent(self, method, body):
         return body[0].children
-        
+
     def method(self, method):
         """
         Get the document root.  For I{rpc/(literal|encoded)}, this is the
@@ -76,7 +76,7 @@ class RPC(Binding):
             ns = ('ns0', ns[1])
         method = Element(method.name, ns=ns)
         return method
-    
+
 
 class Encoded(RPC):
     """

--- a/suds/builder.py
+++ b/suds/builder.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,7 +19,8 @@ The I{builder} module provides an wsdl/xsd defined types factory
 """
 
 from logging import getLogger
-from suds import *
+from suds import TypeNotFound
+from .compat import basestring
 from suds.sudsobject import Factory
 
 log = getLogger(__name__)
@@ -27,17 +28,17 @@ log = getLogger(__name__)
 
 class Builder:
     """ Builder used to construct an object for types defined in the schema """
-    
+
     def __init__(self, resolver):
         """
         @param resolver: A schema object name resolver.
         @type resolver: L{resolver.Resolver}
         """
         self.resolver = resolver
-        
+
     def build(self, name):
-        """ build a an object for the specified typename as defined in the schema """
-        if isinstance(name, str):
+        "build an object for the specified typename as defined in the schema"
+        if isinstance(name, basestring):
             type = self.resolver.find(name)
             if type is None:
                 raise TypeNotFound(name)
@@ -59,7 +60,7 @@ class Builder:
                 continue
             self.process(data, child, history[:])
         return data
-            
+
     def process(self, data, type, history):
         """ process the specified type then process its children """
         if type in history:
@@ -98,15 +99,13 @@ class Builder:
             name = '_%s' % attr.name
             value = attr.get_default()
             setattr(data, name, value)
-                
+
     def skip_child(self, child, ancestry):
         """ get whether or not to skip the specified child """
-        if child.any(): return True
-        for x in ancestry:
-            if x.choice():
-                return True
-        return False
-    
+        if child.any():
+            return True
+        return any(x.choice() for x in ancestry)
+
     def ordering(self, type):
         """ get the ordering """
         result = []
@@ -118,4 +117,3 @@ class Builder:
                 name = '_%s' % child.name
             result.append(name)
         return result
-            

--- a/suds/compat.py
+++ b/suds/compat.py
@@ -1,0 +1,2 @@
+
+basestring = unicode = str

--- a/suds/metrics.py
+++ b/suds/metrics.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -21,10 +21,10 @@ designed for collecting and reporting performance metrics.
 
 import time
 from logging import getLogger
-from suds import *
 from math import modf
 
 log = getLogger(__name__)
+
 
 class Timer:
 
@@ -43,7 +43,7 @@ class Timer:
         return self
 
     def duration(self):
-        return ( self.stopped - self.started )
+        return self.stopped - self.started
 
     def __str__(self):
         if self.started == 0:
@@ -51,10 +51,10 @@ class Timer:
         if self.started > 0 and self.stopped == 0:
             return 'started: %d (running)' % self.started
         duration = self.duration()
-        jmod = ( lambda m : (m[1], m[0]*1000) )
+        jmod = lambda m: (m[1], m[0]*1000)
         if duration < 1:
             ms = (duration*1000)
-            return '%d (ms)' % ms           
+            return '%d (ms)' % ms
         if duration < 60:
             m = modf(duration)
             return '%d.%.3d (seconds)' % jmod(m)

--- a/suds/mx/__init__.py
+++ b/suds/mx/__init__.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -30,9 +30,9 @@ class Content(Object):
     @ivar value: The content's value.
     @type value: I{any}
     """
-    
+
     extensions = []
-    
+
     def __init__(self, tag=None, value=None, **kwargs):
         """
         @param tag: The content tag.
@@ -43,9 +43,9 @@ class Content(Object):
         Object.__init__(self)
         self.tag = tag
         self.value = value
-        for k,v in list(kwargs.items()):
+        for k, v in kwargs.items():
             setattr(self, k, v)
-            
+
     def __getattr__(self, name):
         if name not in self.__dict__:
             if name in self.extensions:

--- a/suds/mx/basic.py
+++ b/suds/mx/basic.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,8 +19,7 @@ Provides basic I{marshaller} classes.
 """
 
 from logging import getLogger
-from suds import *
-from suds.mx import *
+from suds.mx import Content
 from suds.mx.core import Core
 
 log = getLogger(__name__)
@@ -30,7 +29,7 @@ class Basic(Core):
     """
     A I{basic} (untyped) marshaller.
     """
-    
+
     def process(self, value, tag=None):
         """
         Process (marshal) the tag with the specified value using the

--- a/suds/mx/core.py
+++ b/suds/mx/core.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,8 +19,6 @@ Provides I{marshaller} core classes.
 """
 
 from logging import getLogger
-from suds import *
-from suds.mx import *
 from suds.mx.appender import ContentAppender
 from suds.sax.element import Element
 from suds.sax.document import Document
@@ -56,12 +54,12 @@ class Core:
             content.tag = content.value.__class__.__name__
         document = Document()
         if isinstance(content.value, Property):
-            root = self.node(content)
+            root = self.node(content)  # root is never used?
             self.append(document, content)
         else:
             self.append(document, content)
         return document.root()
-    
+
     def append(self, parent, content):
         """
         Append the specified L{content} to the I{parent}.
@@ -90,7 +88,7 @@ class Core:
         @rtype: L{Element}
         """
         return Element(content.tag)
-    
+
     def start(self, content):
         """
         Appending this content has started.
@@ -100,7 +98,7 @@ class Core:
         @rtype: boolean
         """
         return True
-    
+
     def suspend(self, content):
         """
         Appending this content has suspended.
@@ -108,7 +106,7 @@ class Core:
         @type content: L{Content}
         """
         pass
-    
+
     def resume(self, content):
         """
         Appending this content has resumed.
@@ -126,7 +124,7 @@ class Core:
         @type content: L{Content}
         """
         pass
-    
+
     def setnil(self, node, content):
         """
         Set the value of the I{node} to nill.
@@ -147,7 +145,7 @@ class Core:
         @return: The default.
         """
         pass
-    
+
     def optional(self, content):
         """
         Get whether the specified content is optional.
@@ -155,4 +153,3 @@ class Core:
         @type content: L{Content}
         """
         return False
-

--- a/suds/mx/encoded.py
+++ b/suds/mx/encoded.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -26,6 +26,7 @@ from suds.mx.typer import Typer
 from suds.sudsobject import Factory, Object
 from suds.xsd.query import TypeQuery
 
+
 log = getLogger(__name__)
 
 #
@@ -40,16 +41,16 @@ class Encoded(Literal):
     A SOAP section (5) encoding marshaller.
     This marshaller supports rpc/encoded soap styles.
     """
-    
+
     def start(self, content):
         #
         # For soap encoded arrays, the 'aty' (array type) information
         # is extracted and added to the 'content'.  Then, the content.value
         # is replaced with an object containing an 'item=[]' attribute
-        # containing values that are 'typed' suds objects. 
+        # containing values that are 'typed' suds objects.
         #
         start = Literal.start(self, content)
-        if start and isinstance(content.value, (list,tuple)):
+        if start and isinstance(content.value, (list, tuple)):
             resolved = content.type.resolve()
             for c in resolved:
                 if hasattr(c[0], 'aty'):
@@ -57,7 +58,7 @@ class Encoded(Literal):
                     self.cast(content)
                     break
         return start
-    
+
     def end(self, parent, content):
         #
         # For soap encoded arrays, the soapenc:arrayType attribute is
@@ -75,9 +76,9 @@ class Encoded(Literal):
         child.addPrefix(ns0[0], ns0[1])
         child.addPrefix(ns1[0], ns1[1])
         name = '%s:arrayType' % ns1[0]
-        value = '%s:%s[%d]' % (ns0[0], aty[0], len(array)) 
+        value = '%s:%s[%d]' % (ns0[0], aty[0], len(array))
         child.set(name, value)
-        
+
     def encode(self, node, content):
         if content.type.any():
             Typer.auto(node, content.value)
@@ -90,7 +91,7 @@ class Encoded(Literal):
         if self.xstq:
             ns = content.real.namespace()
         Typer.manual(node, name, ns)
-        
+
     def cast(self, content):
         """
         Cast the I{untyped} list items found in content I{value}.
@@ -117,13 +118,13 @@ class Encoded(Literal):
             if isinstance(x, Object):
                 md = x.__metadata__
                 md.sxtype = ref
-                array.item.append(x) 
+                array.item.append(x)
                 continue
             if isinstance(x, dict):
                 x = Factory.object(ref.name, x)
                 md = x.__metadata__
                 md.sxtype = ref
-                array.item.append(x) 
+                array.item.append(x)
                 continue
             x = Factory.property(ref.name, x)
             md = x.__metadata__

--- a/suds/mx/literal.py
+++ b/suds/mx/literal.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,8 +19,8 @@ Provides literal I{marshaller} classes.
 """
 
 from logging import getLogger
-from suds import *
-from suds.mx import *
+from suds import TypeNotFound, Object
+from suds.mx import Content
 from suds.mx.core import Core
 from suds.mx.typer import Typer
 from suds.resolver import GraphResolver, Frame
@@ -41,7 +41,6 @@ Content.extensions.append('real')
 Content.extensions.append('ancestry')
 
 
-
 class Typed(Core):
     """
     A I{typed} marshaller.
@@ -58,17 +57,18 @@ class Typed(Core):
         @param schema: A schema object
         @type schema: L{xsd.schema.Schema}
         @param xstq: The B{x}ml B{s}chema B{t}ype B{q}ualified flag indicates
-            that the I{xsi:type} attribute values should be qualified by namespace.
+            that the I{xsi:type} attribute values should be qualified by
+            namespace.
         @type xstq: bool
         """
         Core.__init__(self)
         self.schema = schema
         self.xstq = xstq
         self.resolver = GraphResolver(self.schema)
-    
+
     def reset(self):
         self.resolver.reset()
-            
+
     def start(self, content):
         #
         # Start marshalling the 'content' by ensuring that both the
@@ -105,7 +105,7 @@ class Typed(Core):
             return False
         else:
             return True
-        
+
     def suspend(self, content):
         #
         # Suspend to process a list content.  Primarily, this
@@ -113,7 +113,7 @@ class Typed(Core):
         # stack so the list items can be marshalled.
         #
         self.resolver.pop()
-    
+
     def resume(self, content):
         #
         # Resume processing a list content.  To do this, we
@@ -121,7 +121,7 @@ class Typed(Core):
         # back onto the resolver stack.
         #
         self.resolver.push(Frame(content.type))
-        
+
     def end(self, parent, content):
         #
         # End processing the content.  Make sure the content
@@ -133,9 +133,10 @@ class Typed(Core):
         if current == content.type:
             self.resolver.pop()
         else:
-            raise Exception('content (end) mismatch: top=(%s) cont=(%s)' % \
-                (current, content))
-    
+            raise Exception('content (end) mismatch: top=(%s) cont=(%s)' % (
+                current,
+                content))
+
     def node(self, content):
         #
         # Create an XML node and namespace qualify as defined
@@ -150,7 +151,7 @@ class Typed(Core):
         self.encode(node, content)
         log.debug('created - node:\n%s', node)
         return node
-    
+
     def setnil(self, node, content):
         #
         # Set the 'node' nil only if the XSD type
@@ -158,7 +159,7 @@ class Typed(Core):
         #
         if content.type.nillable:
             node.setnil()
-            
+
     def setdefault(self, node, content):
         #
         # Set the node to the default value specified
@@ -170,7 +171,7 @@ class Typed(Core):
         else:
             node.setText(default)
         return default
-    
+
     def optional(self, content):
         if content.type.optional():
             return True
@@ -178,7 +179,7 @@ class Typed(Core):
             if a.optional():
                 return True
         return False
-    
+
     def encode(self, node, content):
         # Add (soap) encoding information only if the resolved
         # type is derived by extension.  Further, the xsi:type values
@@ -195,7 +196,7 @@ class Typed(Core):
         if self.xstq:
             ns = content.real.namespace('ns1')
         Typer.manual(node, name, ns)
-    
+
     def skip(self, content):
         """
         Get whether to skip this I{content}.
@@ -210,18 +211,10 @@ class Typed(Core):
             v = content.value
             if v is None:
                 return True
-            if isinstance(v, (list,tuple)) and len(v) == 0:
+            if isinstance(v, (list, tuple)) and len(v) == 0:
                 return True
         return False
-    
-    def optional(self, content):
-        if content.type.optional():
-            return True
-        for a in content.ancestry:
-            if a.optional():
-                return True
-        return False
-    
+
     def translate(self, content):
         """
         Translate using the XSD type information.
@@ -245,7 +238,7 @@ class Typed(Core):
         v = content.real.translate(v, False)
         content.value = v
         return self
-        
+
     def sort(self, content):
         """
         Sort suds object attributes based on ordering defined

--- a/suds/mx/typer.py
+++ b/suds/mx/typer.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,8 +19,7 @@ Provides sx typing classes.
 """
 
 from logging import getLogger
-from suds import *
-from suds.mx import *
+from suds import Object
 from suds.sax import Namespace as NS
 from suds.sax.text import Text
 
@@ -35,21 +34,21 @@ class Typer:
     """
 
     types = {
-        int : ('int', NS.xsdns),
-        int : ('long', NS.xsdns),
-        float : ('float', NS.xsdns),
-        str : ('string', NS.xsdns),
-        str : ('string', NS.xsdns),
-        Text : ('string', NS.xsdns),
-        bool : ('boolean', NS.xsdns),
-     }
-                
+        int: ('int', NS.xsdns),
+        # long: ('long', NS.xsdns),
+        float: ('float', NS.xsdns),
+        str: ('string', NS.xsdns),
+        # unicode: ('string', NS.xsdns),
+        Text: ('string', NS.xsdns),
+        bool: ('boolean', NS.xsdns),
+    }
+
     @classmethod
     def auto(cls, node, value=None):
         """
-        Automatically set the node's xsi:type attribute based on either I{value}'s
-        class or the class of the node's text.  When I{value} is an unmapped class,
-        the default type (xs:any) is set.
+        Automatically set the node's xsi:type attribute based on either
+        I{value}'s class or the class of the node's text.  When I{value} is an
+        unmapped class, the default type (xs:any) is set.
         @param node: An XML node
         @type node: L{sax.element.Element}
         @param value: An object that is or would be the node's text.
@@ -92,9 +91,9 @@ class Typer:
             ns = cls.genprefix(node, ns)
             qname = ':'.join((ns[0], tval))
             node.set(xta, qname)
-            node.addPrefix(ns[0], ns[1]) 
+            node.addPrefix(ns[0], ns[1])
         return node
-    
+
     @classmethod
     def genprefix(cls, node, ns):
         """
@@ -111,7 +110,7 @@ class Typer:
             if u is None or u == ns[1]:
                 return (p, ns[1])
         raise Exception('auto prefix, exhausted')
-    
+
     @classmethod
     def known(cls, object):
         try:
@@ -120,4 +119,3 @@ class Typer:
             return known
         except:
             pass
-

--- a/suds/options.py
+++ b/suds/options.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -18,7 +18,7 @@
 Suds basic options classes.
 """
 
-from suds.properties import *
+from suds.properties import AutoLinker, Unskin, Skin, Definition
 from suds.wsse import Security
 from suds.xsd.doctor import Doctor
 from suds.transport import Transport
@@ -30,7 +30,7 @@ class TpLinker(AutoLinker):
     Transport (auto) linker used to manage linkage between
     transport objects Properties and those Properties that contain them.
     """
-    
+
     def updated(self, properties, prev, next):
         if isinstance(prev, Transport):
             tp = Unskin(prev.options)
@@ -56,7 +56,7 @@ class Options(Skin):
         - B{port} - The default service port name, not tcp port.
                 - type: I{str}
                 - default: None
-        - B{location} - This overrides the service port address I{URL} defined 
+        - B{location} - This overrides the service port address I{URL} defined
             in the WSDL.
                 - type: I{str}
                 - default: None
@@ -99,7 +99,7 @@ class Options(Skin):
                 - default: 0
         - B{plugins} - A plugin container.
                 - type: I{list}
-    """    
+    """
     def __init__(self, **kwargs):
         domain = __name__
         definitions = [

--- a/suds/plugin.py
+++ b/suds/plugin.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,7 +19,6 @@ The plugin module provides classes for implementation
 of suds plugins.
 """
 
-from suds import *
 from logging import getLogger
 
 log = getLogger(__name__)
@@ -51,7 +50,7 @@ class DocumentContext(Context):
     """
     pass
 
-        
+
 class MessageContext(Context):
     """
     The context for sending the soap envelope.
@@ -74,7 +73,7 @@ class InitPlugin(Plugin):
     """
     The base class for suds I{init} plugins.
     """
-    
+
     def initialized(self, context):
         """
         Suds client initialization.
@@ -90,17 +89,17 @@ class DocumentPlugin(Plugin):
     """
     The base class for suds I{document} plugins.
     """
-    
-    def loaded(self, context): 
+
+    def loaded(self, context):
         """
-        Suds has loaded a WSDL/XSD document.  Provides the plugin 
-        with an opportunity to inspect/modify the unparsed document. 
-        Called after each WSDL/XSD document is loaded. 
-        @param context: The document context. 
-        @type context: L{DocumentContext} 
+        Suds has loaded a WSDL/XSD document.  Provides the plugin
+        with an opportunity to inspect/modify the unparsed document.
+        Called after each WSDL/XSD document is loaded.
+        @param context: The document context.
+        @type context: L{DocumentContext}
         """
-        pass 
-    
+        pass
+
     def parsed(self, context):
         """
         Suds has parsed a WSDL/XSD document.  Provides the plugin
@@ -116,7 +115,7 @@ class MessagePlugin(Plugin):
     """
     The base class for suds I{soap message} plugins.
     """
-    
+
     def marshalled(self, context):
         """
         Suds will send the specified soap envelope.
@@ -127,7 +126,7 @@ class MessagePlugin(Plugin):
         @type context: L{MessageContext}
         """
         pass
-    
+
     def sending(self, context):
         """
         Suds will send the specified soap envelope.
@@ -138,7 +137,7 @@ class MessagePlugin(Plugin):
         @type context: L{MessageContext}
         """
         pass
-    
+
     def received(self, context):
         """
         Suds has received the specified reply.
@@ -149,7 +148,7 @@ class MessagePlugin(Plugin):
         @type context: L{MessageContext}
         """
         pass
-    
+
     def parsed(self, context):
         """
         Suds has sax parsed the received reply.
@@ -160,7 +159,7 @@ class MessagePlugin(Plugin):
         @type context: L{MessageContext}
         """
         pass
-    
+
     def unmarshalled(self, context):
         """
         Suds has unmarshalled the received reply.
@@ -172,7 +171,7 @@ class MessagePlugin(Plugin):
         """
         pass
 
-    
+
 class PluginContainer:
     """
     Plugin container provides easy method invocation.
@@ -181,20 +180,20 @@ class PluginContainer:
     @cvar ctxclass: A dict of plugin method / context classes.
     @type ctxclass: dict
     """
-    
-    domains = {\
+
+    domains = {
         'init': (InitContext, InitPlugin),
         'document': (DocumentContext, DocumentPlugin),
-        'message': (MessageContext, MessagePlugin ),
+        'message': (MessageContext, MessagePlugin),
     }
-    
+
     def __init__(self, plugins):
         """
         @param plugins: A list of plugin objects.
         @type plugins: [L{Plugin},]
         """
         self.plugins = plugins
-    
+
     def __getattr__(self, name):
         domain = self.domains.get(name)
         if domain:
@@ -206,8 +205,8 @@ class PluginContainer:
             return PluginDomain(ctx, plugins)
         else:
             raise Exception('plugin domain (%s), invalid' % name)
-        
-        
+
+
 class PluginDomain:
     """
     The plugin domain.
@@ -216,11 +215,11 @@ class PluginDomain:
     @ivar plugins: A list of plugins (targets).
     @type plugins: list
     """
-    
+
     def __init__(self, ctx, plugins):
         self.ctx = ctx
         self.plugins = plugins
-    
+
     def __getattr__(self, name):
         return Method(name, self)
 
@@ -243,7 +242,7 @@ class Method:
         """
         self.name = name
         self.domain = domain
-            
+
     def __call__(self, **kwargs):
         ctx = self.domain.ctx()
         ctx.__dict__.update(kwargs)

--- a/suds/properties.py
+++ b/suds/properties.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,6 +19,7 @@ Properties classes.
 """
 
 from logging import getLogger
+from .utils import is_builtin
 
 log = getLogger(__name__)
 
@@ -58,7 +59,7 @@ class Link(object):
         self.validate(a, b)
         a.links.append(pB)
         b.links.append(pA)
-            
+
     def validate(self, pA, pB):
         """
         Validate that the two properties may be linked.
@@ -80,8 +81,8 @@ class Link(object):
         for d in dB:
             if d in dA:
                 raise Exception('Duplicate domain "%s" found' % d)
-        kA = list(pA.keys())
-        kB = list(pB.keys())
+        kA = pA.keys()
+        kB = pB.keys()
         for k in kA:
             if k in kB:
                 raise Exception('Duplicate key %s found' % k)
@@ -89,7 +90,7 @@ class Link(object):
             if k in kA:
                 raise Exception('Duplicate key %s found' % k)
         return self
-            
+
     def teardown(self):
         """
         Teardown the link.
@@ -116,12 +117,12 @@ class Endpoint(object):
     def __init__(self, link, target):
         self.link = link
         self.target = target
-        
+
     def teardown(self):
         return self.link.teardown()
 
     def __eq__(self, rhs):
-        return ( self.target == rhs )
+        return self.target == rhs
 
     def __hash__(self):
         return hash(self.target)
@@ -155,7 +156,7 @@ class Definition:
         self.classes = classes
         self.default = default
         self.linker = linker
-        
+
     def nvl(self, value=None):
         """
         Convert the I{value} into the default when I{None}.
@@ -168,7 +169,7 @@ class Definition:
             return self.default
         else:
             return value
-        
+
     def validate(self, value):
         """
         Validate the I{value} is of the correct class.
@@ -178,15 +179,13 @@ class Definition:
         """
         if value is None:
             return
-        if len(self.classes) and \
-            not isinstance(value, self.classes):
-                msg = '"%s" must be: %s' % (self.name, self.classes)
-                raise AttributeError(msg)
-                    
-            
+        if len(self.classes) and not isinstance(value, self.classes):
+            msg = '"%s" must be: %s' % (self.name, self.classes)
+            raise AttributeError(msg)
+
     def __repr__(self):
         return '%s: %s' % (self.name, str(self))
-            
+
     def __str__(self):
         s = []
         if len(self.classes):
@@ -210,7 +209,7 @@ class Properties:
         a network of properties.
     @type links: [L{Property},..]
     @ivar defined: A dict of property values.
-    @type defined: dict 
+    @type defined: dict
     """
     def __init__(self, domain, definitions, kwargs):
         """
@@ -219,7 +218,7 @@ class Properties:
         @param definitions: A table of property definitions.
         @type definitions: {name: L{Definition}}
         @param kwargs: A list of property name/values to set.
-        @type kwargs: dict  
+        @type kwargs: dict
         """
         self.definitions = {}
         for d in definitions:
@@ -230,7 +229,7 @@ class Properties:
         self.modified = set()
         self.prime()
         self.update(kwargs)
-        
+
     def definition(self, name):
         """
         Get the definition for the property I{name}.
@@ -244,7 +243,7 @@ class Properties:
         if d is None:
             raise AttributeError(name)
         return d
-    
+
     def update(self, other):
         """
         Update the property values as specified by keyword/value.
@@ -255,10 +254,10 @@ class Properties:
         """
         if isinstance(other, Properties):
             other = other.defined
-        for n,v in list(other.items()):
+        for n, v in other.items():
             self.set(n, v)
         return self
-    
+
     def notset(self, name):
         """
         Get whether a property has never been set by I{name}.
@@ -268,7 +267,7 @@ class Properties:
         @rtype: bool
         """
         self.provider(name).__notset(name)
-            
+
     def set(self, name, value):
         """
         Set the I{value} of a property by I{name}.
@@ -283,7 +282,7 @@ class Properties:
         """
         self.provider(name).__set(name, value)
         return self
-    
+
     def unset(self, name):
         """
         Unset a property by I{name}.
@@ -294,7 +293,7 @@ class Properties:
         """
         self.provider(name).__set(name, None)
         return self
-            
+
     def get(self, name, *df):
         """
         Get the value of a property by I{name}.
@@ -304,13 +303,13 @@ class Properties:
             is not set
         @type df: [1].
         @return: The stored value, or I{df[0]} if not set.
-        @rtype: any 
+        @rtype: any
         """
         return self.provider(name).__get(name, *df)
-    
+
     def link(self, other):
         """
-        Link (associate) this object with anI{other} properties object 
+        Link (associate) this object with anI{other} properties object
         to create a network of properties.  Links are bidirectional.
         @param other: The object to link.
         @type other: L{Properties}
@@ -334,7 +333,7 @@ class Properties:
             if p in others:
                 p.teardown()
         return self
-    
+
     def provider(self, name, history=None):
         """
         Find the provider of the property by I{name}.
@@ -362,7 +361,7 @@ class Properties:
         if len(history):
             return None
         return self
-    
+
     def keys(self, history=None):
         """
         Get the set of I{all} property names.
@@ -376,14 +375,14 @@ class Properties:
             history = []
         history.append(self)
         keys = set()
-        keys.update(list(self.definitions.keys()))
+        keys.update(self.definitions.keys())
         for x in self.links:
             if x in history:
                 continue
             keys.update(x.keys(history))
         history.remove(self)
         return keys
-    
+
     def domains(self, history=None):
         """
         Get the set of I{all} domain names.
@@ -404,7 +403,7 @@ class Properties:
             domains.update(x.domains(history))
         history.remove(self)
         return domains
- 
+
     def prime(self):
         """
         Prime the stored values based on default values
@@ -412,13 +411,13 @@ class Properties:
         @return: self
         @rtype: L{Properties}
         """
-        for d in list(self.definitions.values()):
+        for d in self.definitions.values():
             self.defined[d.name] = d.default
         return self
-    
+
     def __notset(self, name):
         return not (name in self.modified)
-    
+
     def __set(self, name, value):
         d = self.definition(name)
         d.validate(value)
@@ -427,21 +426,21 @@ class Properties:
         self.defined[name] = value
         self.modified.add(name)
         d.linker.updated(self, prev, value)
-        
+
     def __get(self, name, *df):
         d = self.definition(name)
         value = self.defined.get(name)
         if value == d.default and len(df):
             value = df[0]
         return value
-            
+
     def str(self, history):
         s = []
         s.append('Definitions:')
-        for d in list(self.definitions.values()):
+        for d in self.definitions.values():
             s.append('\t%s' % repr(d))
         s.append('Content:')
-        for d in list(self.defined.items()):
+        for d in self.defined.items():
             s.append('\t%s' % str(d))
         if self not in history:
             history.append(self)
@@ -450,10 +449,10 @@ class Properties:
                 s.append(x.str(history))
             history.remove(self)
         return '\n'.join(s)
-            
+
     def __repr__(self):
         return str(self)
-            
+
     def __str__(self):
         return self.str([])
 
@@ -466,36 +465,35 @@ class Skin(object):
     """
     def __init__(self, domain, definitions, kwargs):
         self.__pts__ = Properties(domain, definitions, kwargs)
-        
+
     def __setattr__(self, name, value):
-        builtin = name.startswith('__') and name.endswith('__')
-        if builtin:
+        if is_builtin(name):
             self.__dict__[name] = value
             return
         self.__pts__.set(name, value)
-        
+
     def __getattr__(self, name):
         return self.__pts__.get(name)
-    
+
     def __repr__(self):
         return str(self)
-    
+
     def __str__(self):
         return str(self.__pts__)
-    
-    
+
+
 class Unskin(object):
     def __new__(self, *args, **kwargs):
         return args[0].__pts__
-    
-    
+
+
 class Inspector:
     """
     Wrapper inspector.
     """
     def __init__(self, options):
         self.properties = options.__pts__
-        
+
     def get(self, name, *df):
         """
         Get the value of a property by I{name}.
@@ -505,7 +503,7 @@ class Inspector:
             is not set
         @type df: [1].
         @return: The stored value, or I{df[0]} if not set.
-        @rtype: any 
+        @rtype: any
         """
         return self.properties.get(name, *df)
 
@@ -521,7 +519,7 @@ class Inspector:
 
     def link(self, other):
         """
-        Link (associate) this object with anI{other} properties object 
+        Link (associate) this object with anI{other} properties object
         to create a network of properties.  Links are bidirectional.
         @param other: The object to link.
         @type other: L{Properties}
@@ -530,7 +528,7 @@ class Inspector:
         """
         p = other.__pts__
         return self.properties.link(p)
-    
+
     def unlink(self, other):
         """
         Unlink (disassociate) the specified properties object.

--- a/suds/reader.py
+++ b/suds/reader.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -17,15 +17,14 @@
 """
 Contains xml document reader classes.
 """
-
+import hashlib
+from logging import getLogger
 
 from suds.sax.parser import Parser
 from suds.transport import Request
-from suds.cache import Cache, NoCache
+from suds.cache import NoCache
 from suds.store import DocumentStore
 from suds.plugin import PluginContainer
-from logging import getLogger
-
 
 log = getLogger(__name__)
 
@@ -50,7 +49,7 @@ class Reader:
         Mangle the name by hashing the I{name} and appending I{x}.
         @return: the mangled name.
         """
-        h = abs(hash(name))
+        h = hashlib.sha256(name.encode('utf8')).hexdigest()
         return '%s-%s' % (h, x)
 
 
@@ -59,7 +58,7 @@ class DocumentReader(Reader):
     The XML document reader provides an integration
     between the SAX L{Parser} and the document cache.
     """
-    
+
     def open(self, url):
         """
         Open an XML document at the specified I{url}.
@@ -80,7 +79,7 @@ class DocumentReader(Reader):
             cache.put(id, d)
         self.plugins.document.parsed(url=url, document=d.root())
         return d
-    
+
     def download(self, url):
         """
         Download the docuemnt.
@@ -96,10 +95,10 @@ class DocumentReader(Reader):
         content = fp.read()
         fp.close()
         ctx = self.plugins.document.loaded(url=url, document=content)
-        content = ctx.document 
+        content = ctx.document
         sax = Parser()
         return sax.parse(string=content)
-    
+
     def cache(self):
         """
         Get the cache.
@@ -120,7 +119,7 @@ class DefinitionsReader(Reader):
         create the object not found in the cache.
     @type fn: I{Constructor}
     """
-    
+
     def __init__(self, options, fn):
         """
         @param options: An options object.
@@ -131,14 +130,14 @@ class DefinitionsReader(Reader):
         """
         Reader.__init__(self, options)
         self.fn = fn
-    
+
     def open(self, url):
         """
         Open a WSDL at the specified I{url}.
         First, the WSDL attempted to be retrieved from
         the I{object cache}.  After unpickled from the cache, the
         I{options} attribute is restored.
-        If not found, it is downloaded and instantiated using the 
+        If not found, it is downloaded and instantiated using the
         I{fn} constructor and added to the cache for the next open().
         @param url: A WSDL url.
         @type url: str.

--- a/suds/resolver.py
+++ b/suds/resolver.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -21,10 +21,10 @@ provide wsdl/xsd named type resolution.
 
 import re
 from logging import getLogger
-from suds import *
+from suds import Repr
 from suds.sax import splitPrefix, Namespace
 from suds.sudsobject import Object
-from suds.xsd.query import BlindQuery, TypeQuery, qualify
+from suds.xsd.query import BlindQuery, qualify
 
 log = getLogger(__name__)
 
@@ -42,7 +42,7 @@ class Resolver:
         @type schema: L{xsd.schema.Schema}
         """
         self.schema = schema
-        
+
     def find(self, name, resolved=True):
         """
         Get the definition object for the schema object by name.
@@ -69,7 +69,8 @@ class Resolver:
 
 class PathResolver(Resolver):
     """
-    Resolveds the definition object for the schema type located at the specified path.
+    Resolveds the definition object for the schema type located at the
+    specified path.
     The path may contain (.) dot notation to specify nested types.
     @ivar wsdl: A wsdl object.
     @type wsdl: L{wsdl.Definitions}
@@ -85,11 +86,12 @@ class PathResolver(Resolver):
         Resolver.__init__(self, wsdl.schema)
         self.wsdl = wsdl
         self.altp = re.compile('({)(.+)(})(.+)')
-        self.splitp = re.compile('({.+})*[^\%s]+' % ps[0])
+        self.splitp = re.compile(r'({.+})*[^\%s]+' % ps[0])
 
     def find(self, path, resolved=True):
         """
-        Get the definition object for the schema type located at the specified path.
+        Get the definition object for the schema type located at the specified
+        path.
         The path may contain (.) dot notation to specify nested types.
         Actually, the path separator is usually a (.) but can be redefined
         during contruction.
@@ -114,7 +116,7 @@ class PathResolver(Resolver):
         except PathResolver.BadPath:
             log.error('path: "%s", not-found' % path)
         return result
-    
+
     def root(self, parts):
         """
         Find the path root.
@@ -135,7 +137,7 @@ class PathResolver(Resolver):
         else:
             log.debug('found (%s) as (%s)', name, Repr(result))
         return result
-    
+
     def branch(self, root, parts):
         """
         Traverse the path until the leaf is reached.
@@ -158,7 +160,7 @@ class PathResolver(Resolver):
                 result = result.resolve(nobuiltin=True)
                 log.debug('found (%s) as (%s)', name, Repr(result))
         return result
-    
+
     def leaf(self, parent, parts):
         """
         Find the leaf.
@@ -177,7 +179,7 @@ class PathResolver(Resolver):
         if result is None:
             raise PathResolver.BadPath(name)
         return result
-    
+
     def qualify(self, name):
         """
         Qualify the name as either:
@@ -194,7 +196,7 @@ class PathResolver(Resolver):
             return qualify(name, self.wsdl.root, self.wsdl.tns)
         else:
             return (m.group(4), m.group(2))
-        
+
     def split(self, s):
         """
         Split the string on (.) while preserving any (.) inside the
@@ -210,12 +212,13 @@ class PathResolver(Resolver):
             m = self.splitp.match(s, b)
             if m is None:
                 break
-            b,e = m.span()
+            b, e = m.span()
             parts.append(s[b:e])
-            b = e+1
+            b = e + 1
         return parts
-    
-    class BadPath(Exception): pass
+
+    class BadPath(Exception):
+        pass
 
 
 class TreeResolver(Resolver):
@@ -227,7 +230,7 @@ class TreeResolver(Resolver):
     @ivar stack: The context stack.
     @type stack: list
     """
-    
+
     def __init__(self, schema):
         """
         @param schema: A schema object.
@@ -235,13 +238,13 @@ class TreeResolver(Resolver):
         """
         Resolver.__init__(self, schema)
         self.stack = Stack()
-        
+
     def reset(self):
         """
         Reset the resolver's state.
         """
         self.stack = Stack()
-            
+
     def push(self, x):
         """
         Push an I{object} onto the stack.
@@ -257,7 +260,7 @@ class TreeResolver(Resolver):
         self.stack.append(frame)
         log.debug('push: (%s)\n%s', Repr(frame), Repr(self.stack))
         return frame
-    
+
     def top(self):
         """
         Get the I{frame} at the top of the stack.
@@ -268,21 +271,21 @@ class TreeResolver(Resolver):
             return self.stack[-1]
         else:
             return Frame.Empty()
-        
+
     def pop(self):
         """
         Pop the frame at the top of the stack.
         @return: The popped frame, else None.
         @rtype: L{Frame}
         """
-        if len(self.stack):      
+        if len(self.stack):
             popped = self.stack.pop()
             log.debug('pop: (%s)\n%s', Repr(popped), Repr(self.stack))
             return popped
         else:
             log.debug('stack empty, not-popped')
         return None
-    
+
     def depth(self):
         """
         Get the current stack depth.
@@ -290,7 +293,7 @@ class TreeResolver(Resolver):
         @rtype: int
         """
         return len(self.stack)
-    
+
     def getchild(self, name, parent):
         """ get a child by name """
         log.debug('searching parent (%s) for (%s)', Repr(parent), name)
@@ -307,20 +310,20 @@ class NodeResolver(TreeResolver):
     the tree structure to ensure that nodes are resolved in
     context.
     """
-    
+
     def __init__(self, schema):
         """
         @param schema: A schema object.
         @type schema: L{xsd.schema.Schema}
         """
         TreeResolver.__init__(self, schema)
-        
+
     def find(self, node, resolved=False, push=True):
         """
         @param node: An xml node to be resolved.
         @type node: L{sax.element.Element}
-        @param resolved: A flag indicating that the fully resolved type should be
-            returned.
+        @param resolved: A flag indicating that the fully resolved type should
+            be returned.
         @type resolved: boolean
         @param push: Indicates that the resolved type should be
             pushed onto the stack.
@@ -339,23 +342,23 @@ class NodeResolver(TreeResolver):
             return result
         if push:
             frame = Frame(result, resolved=known, ancestry=ancestry)
-            pushed = self.push(frame)
+            self.push(frame)
         if resolved:
             result = result.resolve()
         return result
-    
+
     def findattr(self, name, resolved=True):
         """
         Find an attribute type definition.
         @param name: An attribute name.
         @type name: basestring
-        @param resolved: A flag indicating that the fully resolved type should be
-            returned.
+        @param resolved: A flag indicating that the fully resolved type should
+            be returned.
         @type resolved: boolean
         @return: The found schema I{type}
         @rtype: L{xsd.sxbase.SchemaObject}
         """
-        name = '@%s'%name
+        name = '@%s' % name
         parent = self.top().resolved
         if parent is None:
             result, ancestry = self.query(name, node)
@@ -366,7 +369,7 @@ class NodeResolver(TreeResolver):
         if resolved:
             result = result.resolve()
         return result
-    
+
     def query(self, name, node):
         """ blindly query the schema by name """
         log.debug('searching schema for (%s)', name)
@@ -374,7 +377,7 @@ class NodeResolver(TreeResolver):
         query = BlindQuery(qref)
         result = query.execute(self.schema)
         return (result, [])
-    
+
     def known(self, node):
         """ resolve type referenced by @xsi:type """
         ref = node.get('type', Namespace.xsins)
@@ -383,7 +386,7 @@ class NodeResolver(TreeResolver):
         qref = qualify(ref, node, node.namespace())
         query = BlindQuery(qref)
         return query.execute(self.schema)
-        
+
 
 class GraphResolver(TreeResolver):
     """
@@ -392,20 +395,20 @@ class GraphResolver(TreeResolver):
     the tree structure to ensure that nodes are resolved in
     context.
     """
-    
+
     def __init__(self, schema):
         """
         @param schema: A schema object.
         @type schema: L{xsd.schema.Schema}
         """
         TreeResolver.__init__(self, schema)
-        
+
     def find(self, name, object, resolved=False, push=True):
         """
         @param name: The name of the object to be resolved.
         @type name: basestring
         @param object: The name's value.
-        @type object: (any|L{Object}) 
+        @type object: (any|L{Object})
         @param resolved: A flag indicating that the fully resolved type
             should be returned.
         @type resolved: boolean
@@ -427,14 +430,14 @@ class GraphResolver(TreeResolver):
             known = self.known(object)
         if push:
             frame = Frame(result, resolved=known, ancestry=ancestry)
-            pushed = self.push(frame)
+            self.push(frame)
         if resolved:
             if known is None:
                 result = result.resolve()
             else:
                 result = known
         return result
-    
+
     def query(self, name):
         """ blindly query the schema by name """
         log.debug('searching schema for (%s)', name)
@@ -447,7 +450,7 @@ class GraphResolver(TreeResolver):
         query = BlindQuery(qref)
         result = query.execute(schema)
         return (result, [])
-    
+
     def wsdl(self):
         """ get the wsdl """
         container = self.schema.container
@@ -455,7 +458,7 @@ class GraphResolver(TreeResolver):
             return None
         else:
             return container.wsdl
-    
+
     def known(self, object):
         """ get the type specified in the object's metadata """
         try:
@@ -465,7 +468,7 @@ class GraphResolver(TreeResolver):
         except:
             pass
 
-       
+
 class Frame:
     def __init__(self, type, resolved=None, ancestry=()):
         self.type = type
@@ -475,11 +478,11 @@ class Frame:
         self.ancestry = ancestry
 
     def __str__(self):
-        return '%s\n%s\n%s' % \
-            (Repr(self.type),
+        return '%s\n%s\n%s' % (
+            Repr(self.type),
             Repr(self.resolved),
             [Repr(t) for t in self.ancestry])
-            
+
     class Empty:
         def __getattr__(self, name):
             if name == 'ancestry':

--- a/suds/sax/__init__.py
+++ b/suds/sax/__init__.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -44,15 +44,14 @@ def splitPrefix(name):
     @param name: A node name containing an optional prefix.
     @type name: basestring
     @return: A tuple containing the (2) parts of I{name}
-    @rtype: (I{prefix}, I{name}) 
+    @rtype: (I{prefix}, I{name})
     """
-    if isinstance(name, str) \
-        and ':' in name:
-            return tuple(name.split(':', 1))
+    if isinstance(name, str) and ':' in name:
+        return tuple(name.split(':', 1))
     else:
         return (None, name)
 
-   
+
 class Namespace:
     """
     The namespace class represents XML namespaces.
@@ -63,15 +62,15 @@ class Namespace:
     xsdns = ('xs', 'http://www.w3.org/2001/XMLSchema')
     xsins = ('xsi', 'http://www.w3.org/2001/XMLSchema-instance')
     all = (xsdns, xsins)
-    
+
     @classmethod
     def create(cls, p=None, u=None):
         return (p, u)
-    
+
     @classmethod
     def none(cls, ns):
-        return ( ns == cls.default )
-    
+        return ns == cls.default
+
     @classmethod
     def xsd(cls, ns):
         try:
@@ -79,7 +78,7 @@ class Namespace:
         except:
             pass
         return False
-    
+
     @classmethod
     def xsi(cls, ns):
         try:
@@ -87,10 +86,10 @@ class Namespace:
         except:
             pass
         return False
-    
+
     @classmethod
     def xs(cls, ns):
-        return ( cls.xsd(ns) or cls.xsi(ns) )
+        return cls.xsd(ns) or cls.xsi(ns)
 
     @classmethod
     def w3(cls, ns):
@@ -99,7 +98,7 @@ class Namespace:
         except:
             pass
         return False
-    
+
     @classmethod
     def isns(cls, ns):
         try:

--- a/suds/sax/attribute.py
+++ b/suds/sax/attribute.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -18,13 +18,13 @@
 Provides XML I{attribute} classes.
 """
 
-import suds.sax
 from logging import getLogger
-from suds import *
-from suds.sax import *
+from suds.sax import Namespace, splitPrefix
 from suds.sax.text import Text
+from suds.compat import unicode
 
 log = getLogger(__name__)
+
 
 class Attribute:
     """
@@ -43,12 +43,12 @@ class Attribute:
         @param name: The attribute's name with I{optional} namespace prefix.
         @type name: basestring
         @param value: The attribute's value
-        @type value: basestring 
+        @type value: basestring
         """
         self.parent = None
         self.prefix, self.name = splitPrefix(name)
         self.setValue(value)
-        
+
     def clone(self, parent=None):
         """
         Clone this object.
@@ -60,7 +60,7 @@ class Attribute:
         a = Attribute(self.qname(), self.value)
         a.parent = parent
         return a
-    
+
     def qname(self):
         """
         Get the B{fully} qualified name of this attribute
@@ -71,7 +71,7 @@ class Attribute:
             return self.name
         else:
             return ':'.join((self.prefix, self.name))
-        
+
     def setValue(self, value):
         """
         Set the attributes value
@@ -85,7 +85,7 @@ class Attribute:
         else:
             self.value = Text(value)
         return self
-        
+
     def getValue(self, default=Text('')):
         """
         Get the attributes value with optional default.
@@ -99,7 +99,7 @@ class Attribute:
             return self.value
         else:
             return default
-    
+
     def hasText(self):
         """
         Get whether the attribute has I{text} and that it is not an empty
@@ -107,8 +107,8 @@ class Attribute:
         @return: True when has I{text}.
         @rtype: boolean
         """
-        return ( self.value is not None and len(self.value) )
-        
+        return self.value is not None and len(self.value)
+
     def namespace(self):
         """
         Get the attributes namespace.  This may either be the namespace
@@ -120,7 +120,7 @@ class Attribute:
             return Namespace.default
         else:
             return self.resolvePrefix(self.prefix)
-        
+
     def resolvePrefix(self, prefix):
         """
         Resolve the specified prefix to a known namespace.
@@ -133,7 +133,7 @@ class Attribute:
         if self.parent is not None:
             ns = self.parent.resolvePrefix(prefix)
         return ns
-    
+
     def match(self, name=None, ns=None):
         """
         Match by (optional) name and/or (optional) namespace.
@@ -147,30 +147,36 @@ class Attribute:
         if name is None:
             byname = True
         else:
-            byname = ( self.name == name )
+            byname = self.name == name
         if ns is None:
             byns = True
         else:
-            byns = ( self.namespace()[1] == ns[1] )
-        return ( byname and byns )
-    
+            byns = self.namespace()[1] == ns[1]
+        return byname and byns
+
     def __eq__(self, rhs):
         """ equals operator """
         return rhs is not None and \
             isinstance(rhs, Attribute) and \
             self.prefix == rhs.name and \
             self.name == rhs.name
-            
+
     def __repr__(self):
         """ get a string representation """
-        return \
-            'attr (prefix=%s, name=%s, value=(%s))' %\
-                (self.prefix, self.name, self.value)
+        return 'attr (prefix=%s, name=%s, value=(%s))' % (
+            self.prefix,
+            self.name,
+            self.value)
 
     def __str__(self):
         """ get an xml string representation """
-        return str(self)
-    
+        n = self.qname()
+        if self.hasText():
+            v = self.value.escape()
+        else:
+            v = self.value
+        return u'%s="%s"' % (n, v)
+
     def __unicode__(self):
         """ get an xml string representation """
         n = self.qname()
@@ -178,4 +184,4 @@ class Attribute:
             v = self.value.escape()
         else:
             v = self.value
-        return '%s="%s"' % (n, v)
+        return u'%s="%s"' % (n, v)

--- a/suds/sax/document.py
+++ b/suds/sax/document.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,35 +19,35 @@ Provides XML I{document} classes.
 """
 
 from logging import getLogger
-from suds import *
-from suds.sax import *
 from suds.sax.element import Element
 
 log = getLogger(__name__)
 
+
 class Document(Element):
     """ simple document """
-    
+
     DECL = '<?xml version="1.0" encoding="UTF-8"?>'
 
     def __init__(self, root=None):
         Element.__init__(self, 'document')
         if root is not None:
             self.append(root)
-        
+
     def root(self):
         if len(self.children):
             return self.children[0]
         else:
             return None
-        
+
     def str(self):
         s = []
         s.append(self.DECL)
         s.append('\n')
-        s.append(self.root().str())
+        if self.root() is not None:
+            s.append(self.root().str())
         return ''.join(s)
-    
+
     def plain(self):
         s = []
         s.append(self.DECL)
@@ -55,7 +55,7 @@ class Document(Element):
         return ''.join(s)
 
     def __str__(self):
-        return str(self)
-    
+        return self.str()
+
     def __unicode__(self):
         return self.str()

--- a/suds/sax/element.py
+++ b/suds/sax/element.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,16 +19,13 @@ Provides XML I{element} classes.
 """
 
 from logging import getLogger
-from suds import *
-from suds.sax import *
+from suds.compat import unicode, basestring
+from suds.sax import Namespace, splitPrefix
 from suds.sax.text import Text
 from suds.sax.attribute import Attribute
-import sys 
-if sys.version_info < (2, 4, 0): 
-    from sets import Set as set 
-    del sys 
 
 log = getLogger(__name__)
+
 
 class Element:
     """
@@ -53,21 +50,22 @@ class Element:
     @cvar specialprefixes: A dictionary of builtin-special prefixes.
     """
 
-    matcher = \
-    {
-        'eq': lambda a,b: a == b,
-        'startswith' : lambda a,b: a.startswith(b),
-        'endswith' : lambda a,b: a.endswith(b),
-        'contains' : lambda a,b: b in a 
+    matcher = {
+        'eq': lambda a, b: a == b,
+        'startswith': lambda a, b: a.startswith(b),
+        'endswith': lambda a, b: a.endswith(b),
+        'contains': lambda a, b: b in a
     }
-    
-    specialprefixes = { Namespace.xmlns[0] : Namespace.xmlns[1]  }
-    
+
+    specialprefixes = {
+        Namespace.xmlns[0]: Namespace.xmlns[1]
+    }
+
     @classmethod
     def buildPath(self, parent, path):
         """
-        Build the specifed pat as a/b/c where missing intermediate nodes are built
-        automatically.
+        Build the specifed pat as a/b/c where missing intermediate nodes are
+        built automatically.
         @param parent: A parent element on which the path is built.
         @type parent: I{Element}
         @param path: A simple path separated by (/).
@@ -91,7 +89,7 @@ class Element:
         @param ns: An optional namespace
         @type ns: (I{prefix}, I{name})
         """
-        
+
         self.rename(name)
         self.expns = None
         self.nsprefixes = {}
@@ -106,23 +104,23 @@ class Element:
             self.parent = None
         self.children = []
         self.applyns(ns)
-        
+
     def rename(self, name):
         """
         Rename the element.
         @param name: A new name for the element.
-        @type name: basestring 
+        @type name: basestring
         """
         if name is None:
             raise Exception('name (%s) not-valid' % name)
         else:
             self.prefix, self.name = splitPrefix(name)
-            
+
     def setPrefix(self, p, u=None):
         """
         Set the element namespace prefix.
         @param p: A new prefix for the element.
-        @type p: basestring 
+        @type p: basestring
         @param u: A namespace URI to be mapped to the prefix.
         @type u: basestring
         @return: self
@@ -143,7 +141,7 @@ class Element:
             return self.name
         else:
             return '%s:%s' % (self.prefix, self.name)
-        
+
     def getRoot(self):
         """
         Get the root (top) node of the tree.
@@ -154,7 +152,7 @@ class Element:
             return self
         else:
             return self.parent.getRoot()
-        
+
     def clone(self, parent=None):
         """
         Deep clone of this element and children.
@@ -168,10 +166,10 @@ class Element:
             root.append(a.clone(self))
         for c in self.children:
             root.append(c.clone(self))
-        for item in list(self.nsprefixes.items()):
+        for item in self.nsprefixes.items():
             root.addPrefix(item[0], item[1])
         return root
-    
+
     def detach(self):
         """
         Detach from parent.
@@ -184,7 +182,7 @@ class Element:
                 self.parent.children.remove(self)
             self.parent = None
         return self
-        
+
     def set(self, name, value):
         """
         Set an attribute's value.
@@ -200,7 +198,7 @@ class Element:
             self.append(attr)
         else:
             attr.setValue(value)
-            
+
     def unset(self, name):
         """
         Unset (remove) an attribute.
@@ -215,8 +213,7 @@ class Element:
         except:
             pass
         return self
-            
-            
+
     def get(self, name, ns=None, default=None):
         """
         Get the value of an attribute by name.
@@ -235,7 +232,7 @@ class Element:
         if attr is None or attr.value is None:
             return default
         else:
-            return attr.getValue()   
+            return attr.getValue()
 
     def setText(self, value):
         """
@@ -250,7 +247,7 @@ class Element:
         else:
             self.text = Text(value)
         return self
-        
+
     def getText(self, default=None):
         """
         Get the element's L{Text} content with optional default
@@ -263,7 +260,7 @@ class Element:
             return self.text
         else:
             return default
-    
+
     def trim(self):
         """
         Trim leading and trailing whitespace.
@@ -273,7 +270,7 @@ class Element:
         if self.hasText():
             self.text = self.text.trim()
         return self
-    
+
     def hasText(self):
         """
         Get whether the element has I{text} and that it is not an empty
@@ -281,12 +278,12 @@ class Element:
         @return: True when has I{text}.
         @rtype: boolean
         """
-        return ( self.text is not None and len(self.text) )
-        
+        return self.text is not None and len(self.text)
+
     def namespace(self):
         """
         Get the element's namespace.
-        @return: The element's namespace by resolving the prefix, the explicit 
+        @return: The element's namespace by resolving the prefix, the explicit
             namespace or the inherited namespace.
         @rtype: (I{prefix}, I{name})
         """
@@ -294,10 +291,10 @@ class Element:
             return self.defaultNamespace()
         else:
             return self.resolvePrefix(self.prefix)
-        
+
     def defaultNamespace(self):
         """
-        Get the default (unqualified namespace).  
+        Get the default (unqualified namespace).
         This is the expns of the first node (looking up the tree)
         that has it set.
         @return: The namespace of a node when not qualified.
@@ -310,7 +307,7 @@ class Element:
             else:
                 p = p.parent
         return Namespace.default
-            
+
     def append(self, objects):
         """
         Append the specified child based on whether it is an
@@ -334,7 +331,7 @@ class Element:
                 continue
             raise Exception('append %s not-valid' % child.__class__.__name__)
         return self
-    
+
     def insert(self, objects, index=0):
         """
         Insert an L{Element} content at the specified index.
@@ -354,7 +351,7 @@ class Element:
             else:
                 raise Exception('append %s not-valid' % child.__class__.__name__)
         return self
-    
+
     def remove(self, child):
         """
         Remove the specified child element or attribute.
@@ -368,7 +365,7 @@ class Element:
         if isinstance(child, Attribute):
             self.attributes.remove(child)
         return None
-            
+
     def replaceChild(self, child, content):
         """
         Replace I{child} with the specified I{content}.
@@ -387,7 +384,7 @@ class Element:
             self.children.insert(index, node.detach())
             node.parent = self
             index += 1
-            
+
     def getAttribute(self, name, ns=None, default=None):
         """
         Get an attribute by name and (optional) namespace
@@ -433,7 +430,7 @@ class Element:
             if c.match(name, ns):
                 return c
         return default
-    
+
     def childAtPath(self, path):
         """
         Get a child at I{path} where I{path} is a (/) separated
@@ -452,7 +449,7 @@ class Element:
                 ns = node.resolvePrefix(prefix)
             result = node.getChild(name, ns)
             if result is None:
-                break;
+                break
             else:
                 node = result
         return result
@@ -472,7 +469,7 @@ class Element:
         else:
             result = self.__childrenAtPath(parts)
         return result
-        
+
     def getChildren(self, name=None, ns=None):
         """
         Get a list of children by (optional) name and/or (optional) namespace.
@@ -492,7 +489,7 @@ class Element:
             else:
                 ns = self.resolvePrefix(prefix)
         return [c for c in self.children if c.match(name, ns)]
-    
+
     def detachChildren(self):
         """
         Detach and return this element's children.
@@ -504,7 +501,7 @@ class Element:
         for child in detached:
             child.parent = None
         return detached
-        
+
     def resolvePrefix(self, prefix, default=Namespace.default):
         """
         Resolve the specified prefix to a namespace.  The I{nsprefixes} is
@@ -527,7 +524,7 @@ class Element:
                 return (prefix, self.specialprefixes[prefix])
             n = n.parent
         return default
-    
+
     def addPrefix(self, p, u):
         """
         Add or update a prefix mapping.
@@ -540,10 +537,10 @@ class Element:
         """
         self.nsprefixes[p] = u
         return self
- 
+
     def updatePrefix(self, p, u):
         """
-        Update (redefine) a prefix mapping for the branch. 
+        Update (redefine) a prefix mapping for the branch.
         @param p: A prefix.
         @type p: basestring
         @param u: A namespace URI.
@@ -557,7 +554,7 @@ class Element:
         for c in self.children:
             c.updatePrefix(p, u)
         return self
-            
+
     def clearPrefix(self, prefix):
         """
         Clear the specified prefix from the prefix mappings.
@@ -569,7 +566,7 @@ class Element:
         if prefix in self.nsprefixes:
             del self.nsprefixes[prefix]
         return self
-    
+
     def findPrefix(self, uri, default=None):
         """
         Find the first prefix that has been mapped to a namespace URI.
@@ -582,14 +579,14 @@ class Element:
         @return: A mapped prefix.
         @rtype: basestring
         """
-        for item in list(self.nsprefixes.items()):
+        for item in self.nsprefixes.items():
             if item[1] == uri:
                 prefix = item[0]
                 return prefix
-        for item in list(self.specialprefixes.items()):
+        for item in self.specialprefixes.items():
             if item[1] == uri:
                 prefix = item[0]
-                return prefix      
+                return prefix
         if self.parent is not None:
             return self.parent.findPrefix(uri, default)
         else:
@@ -608,18 +605,18 @@ class Element:
         @rtype: [basestring,...]
         """
         result = []
-        for item in list(self.nsprefixes.items()):
+        for item in self.nsprefixes.items():
             if self.matcher[match](item[1], uri):
                 prefix = item[0]
                 result.append(prefix)
-        for item in list(self.specialprefixes.items()):
+        for item in self.specialprefixes.items():
             if self.matcher[match](item[1], uri):
                 prefix = item[0]
                 result.append(prefix)
         if self.parent is not None:
             result += self.parent.findPrefixes(uri, match)
         return result
-    
+
     def promotePrefixes(self):
         """
         Push prefix declarations up the tree as far as possible.  Prefix
@@ -633,17 +630,22 @@ class Element:
             c.promotePrefixes()
         if self.parent is None:
             return
-        for p,u in list(self.nsprefixes.items()):
+        _pref = []
+        for p, u in self.nsprefixes.items():
             if p in self.parent.nsprefixes:
                 pu = self.parent.nsprefixes[p]
                 if pu == u:
-                    del self.nsprefixes[p]
+                    _pref.append(p)
                 continue
             if p != self.parent.prefix:
                 self.parent.nsprefixes[p] = u
-                del self.nsprefixes[p]
+                _pref.append(p)
+
+        for x in _pref:
+            del self.nsprefixes[x]
+
         return self
-    
+
     def refitPrefixes(self):
         """
         Refit namespace qualification by replacing prefixes
@@ -660,13 +662,13 @@ class Element:
         self.prefix = None
         self.nsprefixes = {}
         return self
-                
+
     def normalizePrefixes(self):
         """
         Normalize the namespace prefixes.
         This generates unique prefixes for all namespaces.  Then retrofits all
-        prefixes and prefix mappings.  Further, it will retrofix attribute values
-        that have values containing (:).
+        prefixes and prefix mappings.  Further, it will retrofix attribute
+        values that have values containing (:).
         @return: self
         @rtype: L{Element}
         """
@@ -683,14 +685,13 @@ class Element:
         """
         noattrs = not len(self.attributes)
         nochildren = not len(self.children)
-        notext = ( self.text is None )
-        nocontent = ( nochildren and notext )
+        notext = self.text is None
+        nocontent = nochildren and notext
         if content:
             return nocontent
         else:
-            return ( nocontent and noattrs )
-            
-            
+            return nocontent and noattrs
+
     def isnil(self):
         """
         Get whether the element is I{nil} as defined by having
@@ -702,8 +703,8 @@ class Element:
         if nilattr is None:
             return False
         else:
-            return ( nilattr.getValue().lower() == 'true' )
-        
+            return nilattr.getValue().lower() == 'true'
+
     def setnil(self, flag=True):
         """
         Set this node to I{nil} as defined by having an
@@ -714,13 +715,13 @@ class Element:
         @rtype: L{Element}
         """
         p, u = Namespace.xsins
-        name  = ':'.join((p, 'nil'))
+        name = ':'.join((p, 'nil'))
         self.set(name, str(flag).lower())
         self.addPrefix(p, u)
         if flag:
             self.text = None
         return self
-            
+
     def applyns(self, ns):
         """
         Apply the namespace to this node.  If the prefix is I{None} then
@@ -731,14 +732,14 @@ class Element:
         """
         if ns is None:
             return
-        if not isinstance(ns, (tuple,list)):
+        if not isinstance(ns, (tuple, list)):
             raise Exception('namespace must be tuple')
         if ns[0] is None:
             self.expns = ns[1]
         else:
             self.prefix = ns[0]
             self.nsprefixes[ns[0]] = ns[1]
-            
+
     def str(self, indent=0):
         """
         Get a string representation of this XML fragment.
@@ -747,11 +748,11 @@ class Element:
         @return: A I{pretty} string.
         @rtype: basestring
         """
-        tab = '%*s'%(indent*3,'')
+        tab = '%*s' % (indent * 3, '')
         result = []
         result.append('%s<%s' % (tab, self.qname()))
         result.append(self.nsdeclarations())
-        for a in [str(a) for a in self.attributes]:
+        for a in [unicode(a) for a in self.attributes]:
             result.append(' %s' % a)
         if self.isempty():
             result.append('/>')
@@ -767,7 +768,7 @@ class Element:
         result.append('</%s>' % self.qname())
         result = ''.join(result)
         return result
-    
+
     def plain(self):
         """
         Get a string representation of this XML fragment.
@@ -777,7 +778,7 @@ class Element:
         result = []
         result.append('<%s' % self.qname())
         result.append(self.nsdeclarations())
-        for a in [str(a) for a in self.attributes]:
+        for a in [unicode(a) for a in self.attributes]:
             result.append(' %s' % a)
         if self.isempty():
             result.append('/>')
@@ -808,15 +809,15 @@ class Element:
             if self.expns is not None:
                 d = ' xmlns="%s"' % self.expns
                 s.append(d)
-        for item in list(self.nsprefixes.items()):
-            (p,u) = item
+        for p, u in self.nsprefixes.items():
             if self.parent is not None:
                 ns = self.parent.resolvePrefix(p)
-                if ns[1] == u: continue
+                if ns[1] == u:
+                    continue
             d = ' xmlns:%s="%s"' % (p, u)
             s.append(d)
         return ''.join(s)
-    
+
     def match(self, name=None, ns=None):
         """
         Match by (optional) name and/or (optional) namespace.
@@ -830,13 +831,13 @@ class Element:
         if name is None:
             byname = True
         else:
-            byname = ( self.name == name )
+            byname = self.name == name
         if ns is None:
             byns = True
         else:
-            byns = ( self.namespace()[1] == ns[1] )
-        return ( byname and byns )
-    
+            byns = self.namespace()[1] == ns[1]
+        return byname and byns
+
     def branch(self):
         """
         Get a flattened representation of the branch.
@@ -847,7 +848,7 @@ class Element:
         for c in self.children:
             branch += c.branch()
         return branch
-    
+
     def ancestors(self):
         """
         Get a list of ancestors.
@@ -860,7 +861,7 @@ class Element:
             ancestors.append(p)
             p = p.parent
         return ancestors
-    
+
     def walk(self, visitor):
         """
         Walk the branch and call the visitor function
@@ -873,7 +874,7 @@ class Element:
         for c in self.children:
             c.walk(visitor)
         return self
-    
+
     def prune(self):
         """
         Prune the branch of empty nodes.
@@ -885,8 +886,7 @@ class Element:
                 pruned.append(c)
         for p in pruned:
             self.children.remove(p)
-                
-            
+
     def __childrenAtPath(self, parts):
         result = []
         node = self
@@ -910,46 +910,45 @@ class Element:
                 ns = node.resolvePrefix(prefix)
             result = child.getChildren(leaf)
         return result
-    
+
     def __len__(self):
         return len(self.children)
-                
+
     def __getitem__(self, index):
-        if isinstance(index, str):
+        if isinstance(index, basestring):
             return self.get(index)
         else:
             if index < len(self.children):
                 return self.children[index]
             else:
                 return None
-        
+
     def __setitem__(self, index, value):
-        if isinstance(index, str):
+        if isinstance(index, basestring):
             self.set(index, value)
         else:
-            if index < len(self.children) and \
-                isinstance(value, Element):
+            if index < len(self.children) and isinstance(value, Element):
                 self.children.insert(index, value)
 
     def __eq__(self, rhs):
-        return  rhs is not None and \
+        return rhs is not None and \
             isinstance(rhs, Element) and \
             self.name == rhs.name and \
             self.namespace()[1] == rhs.namespace()[1]
-        
+
     def __repr__(self):
         return \
             'Element (prefix=%s, name=%s)' % (self.prefix, self.name)
-    
+
     def __str__(self):
-        return str(self)
-    
+        return self.str()
+
     def __unicode__(self):
         return self.str()
-    
+
     def __iter__(self):
         return NodeIterator(self)
-    
+
 
 class NodeIterator:
     """
@@ -957,9 +956,9 @@ class NodeIterator:
     @ivar pos: The current position
     @type pos: int
     @ivar children: A list of a child nodes.
-    @type children: [L{Element},..] 
+    @type children: [L{Element},..]
     """
-    
+
     def __init__(self, parent):
         """
         @param parent: An element to iterate.
@@ -967,8 +966,11 @@ class NodeIterator:
         """
         self.pos = 0
         self.children = parent.children
-        
+
     def __next__(self):
+        return self.next()
+
+    def next(self):
         """
         Get the next child.
         @return: The next child.
@@ -995,7 +997,7 @@ class PrefixNormalizer:
     @ivar prefixes: A reverse dict of prefixes.
     @type prefixes: {u, p}
     """
-    
+
     @classmethod
     def apply(cls, node):
         """
@@ -1007,7 +1009,7 @@ class PrefixNormalizer:
         """
         pn = PrefixNormalizer(node)
         return pn.refit()
-    
+
     def __init__(self, node):
         """
         @param node: A node to normalize.
@@ -1017,7 +1019,7 @@ class PrefixNormalizer:
         self.branch = node.branch()
         self.namespaces = self.getNamespaces()
         self.prefixes = self.genPrefixes()
-        
+
     def getNamespaces(self):
         """
         Get the I{unique} set of namespaces referenced in the branch.
@@ -1030,7 +1032,7 @@ class PrefixNormalizer:
                 s.add(n.expns)
             s = s.union(self.pset(n))
         return s
-    
+
     def pset(self, n):
         """
         Convert the nodes nsprefixes into a set.
@@ -1040,11 +1042,11 @@ class PrefixNormalizer:
         @rtype: set
         """
         s = set()
-        for ns in list(n.nsprefixes.items()):
+        for ns in n.nsprefixes.items():
             if self.permit(ns):
                 s.add(ns[1])
         return s
-            
+
     def genPrefixes(self):
         """
         Generate a I{reverse} mapping of unique prefixes for all namespaces.
@@ -1058,14 +1060,14 @@ class PrefixNormalizer:
             prefixes[u] = p
             n += 1
         return prefixes
-    
+
     def refit(self):
         """
         Refit (normalize) the prefixes in the node.
         """
         self.refitNodes()
         self.refitMappings()
-    
+
     def refitNodes(self):
         """
         Refit (normalize) all of the nodes in the branch.
@@ -1076,7 +1078,7 @@ class PrefixNormalizer:
                 if self.permit(ns):
                     n.prefix = self.prefixes[ns[1]]
             self.refitAttrs(n)
-                
+
     def refitAttrs(self, n):
         """
         Refit (normalize) all of the attributes in the node.
@@ -1085,7 +1087,7 @@ class PrefixNormalizer:
         """
         for a in n.attributes:
             self.refitAddr(a)
-    
+
     def refitAddr(self, a):
         """
         Refit (normalize) the attribute.
@@ -1097,21 +1099,22 @@ class PrefixNormalizer:
             if self.permit(ns):
                 a.prefix = self.prefixes[ns[1]]
         self.refitValue(a)
-    
+
     def refitValue(self, a):
         """
         Refit (normalize) the attribute's value.
         @param a: An attribute.
         @type a: L{Attribute}
         """
-        p,name = splitPrefix(a.getValue())
-        if p is None: return
+        p, name = splitPrefix(a.getValue())
+        if p is None:
+            return
         ns = a.resolvePrefix(p)
         if self.permit(ns):
             u = ns[1]
             p = self.prefixes[u]
             a.setValue(':'.join((p, name)))
-            
+
     def refitMappings(self):
         """
         Refit (normalize) all of the nsprefix mappings.
@@ -1119,9 +1122,9 @@ class PrefixNormalizer:
         for n in self.branch:
             n.nsprefixes = {}
         n = self.node
-        for u, p in list(self.prefixes.items()):
+        for u, p in self.prefixes.items():
             n.addPrefix(p, u)
-            
+
     def permit(self, ns):
         """
         Get whether the I{ns} is to be normalized.
@@ -1131,7 +1134,7 @@ class PrefixNormalizer:
         @rtype: boolean
         """
         return not self.skip(ns)
-            
+
     def skip(self, ns):
         """
         Get whether the I{ns} is to B{not} be normalized.
@@ -1140,8 +1143,4 @@ class PrefixNormalizer:
         @return: True if to be skipped.
         @rtype: boolean
         """
-        return ns is None or \
-            ( ns == Namespace.default ) or \
-            ( ns == Namespace.xsdns ) or \
-            ( ns == Namespace.xsins) or \
-            ( ns == Namespace.xmlns )
+        return ns in (None, Namespace.default, Namespace.xsdns, Namespace.xsins, Namespace.xmlns)

--- a/suds/sax/enc.py
+++ b/suds/sax/enc.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -20,6 +20,7 @@ Provides XML I{special character} encoder classes.
 
 import re
 
+
 class Encoder:
     """
     An XML special character encoder/decoder.
@@ -30,14 +31,23 @@ class Encoder:
     @cvar special: A list of special characters
     @type special: [char]
     """
-    
-    encodings = \
-        (( '&(?!(amp|lt|gt|quot|apos);)', '&amp;' ),( '<', '&lt;' ),( '>', '&gt;' ),( '"', '&quot;' ),("'", '&apos;' ))
-    decodings = \
-        (( '&lt;', '<' ),( '&gt;', '>' ),( '&quot;', '"' ),( '&apos;', "'" ),( '&amp;', '&' ))
-    special = \
-        ('&', '<', '>', '"', "'")
-    
+
+    encodings = (
+        ('&', '&amp;'),
+        ('<', '&lt;'),
+        ('>', '&gt;'),
+        ('"', '&quot;'),
+        ("'", '&apos;')
+    )
+    decodings = (
+        ('&lt;', '<'),
+        ('&gt;', '>'),
+        ('&quot;', '"'),
+        ('&apos;', "'"),
+        ('&amp;', '&')
+    )
+    special = ('&', '<', '>', '"', "'")
+
     def needsEncoding(self, s):
         """
         Get whether string I{s} contains special characters.
@@ -51,7 +61,7 @@ class Encoder:
                 if c in s:
                     return True
         return False
-    
+
     def encode(self, s):
         """
         Encode special characters found in string I{s}.
@@ -64,7 +74,7 @@ class Encoder:
             for x in self.encodings:
                 s = re.sub(x[0], x[1], s)
         return s
-    
+
     def decode(self, s):
         """
         Decode special characters encodings found in string I{s}.

--- a/suds/sax/text.py
+++ b/suds/sax/text.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -18,8 +18,7 @@
 Contains XML text classes.
 """
 
-from suds import *
-from suds.sax import *
+from suds import sax
 
 
 class Text(str):
@@ -31,11 +30,11 @@ class Text(str):
     @type escaped: bool
     """
     __slots__ = ('lang', 'escaped',)
-    
+
     @classmethod
     def __valid(cls, *args):
-        return ( len(args) and args[0] is not None )
-    
+        return len(args) and args[0] is not None
+
     def __new__(cls, *args, **kwargs):
         if cls.__valid(*args):
             lang = kwargs.pop('lang', None)
@@ -46,7 +45,7 @@ class Text(str):
         else:
             result = None
         return result
-    
+
     def escape(self):
         """
         Encode (escape) special XML characters.
@@ -55,10 +54,10 @@ class Text(str):
         """
         if not self.escaped:
             post = sax.encoder.encode(self)
-            escaped = ( post != self )
+            escaped = post != self
             return Text(post, lang=self.lang, escaped=escaped)
         return self
-    
+
     def unescape(self):
         """
         Decode (unescape) special XML characters.
@@ -69,37 +68,37 @@ class Text(str):
             post = sax.encoder.decode(self)
             return Text(post, lang=self.lang)
         return self
-    
+
     def trim(self):
         post = self.strip()
         return Text(post, lang=self.lang, escaped=self.escaped)
-    
+
     def __add__(self, other):
-        joined = ''.join((self, other))
+        joined = u''.join((self, other))
         result = Text(joined, lang=self.lang, escaped=self.escaped)
         if isinstance(other, Text):
-            result.escaped = ( self.escaped or other.escaped )
+            result.escaped = self.escaped or other.escaped
         return result
-    
+
     def __repr__(self):
         s = [self]
         if self.lang is not None:
             s.append(' [%s]' % self.lang)
         if self.escaped:
             s.append(' <escaped>')
-        return ''.join(s)
-    
+        return ''.join(s).__repr__()
+
     def __getstate__(self):
         state = {}
         for k in self.__slots__:
             state[k] = getattr(self, k)
         return state
-    
+
     def __setstate__(self, state):
         for k in self.__slots__:
             setattr(self, k, state[k])
-    
-    
+
+
 class Raw(Text):
     """
     Raw text which is not XML escaped.
@@ -107,10 +106,10 @@ class Raw(Text):
     """
     def escape(self):
         return self
-    
+
     def unescape(self):
         return self
-    
+
     def __add__(self, other):
-        joined = ''.join((self, other))
+        joined = u''.join((self, other))
         return Raw(joined, lang=self.lang)

--- a/suds/servicedefinition.py
+++ b/suds/servicedefinition.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,16 +19,17 @@ The I{service definition} provides a textual representation of a service.
 """
 
 from logging import getLogger
-from suds import *
+from suds import tostr
 import suds.metrics as metrics
 from suds.sax import Namespace
 
 log = getLogger(__name__)
 
+
 class ServiceDefinition:
     """
-    A service definition provides an object used to generate a textual description
-    of a service.
+    A service definition provides an object used to generate a textual
+    description of a service.
     @ivar wsdl: A wsdl.
     @type wsdl: L{wsdl.Definitions}
     @ivar service: The service object.
@@ -38,9 +39,9 @@ class ServiceDefinition:
     @ivar prefixes: A list of remapped prefixes.
     @type prefixes: [(prefix,uri),..]
     @ivar types: A list of type definitions
-    @type types: [I{Type},..] 
+    @type types: [I{Type},..]
     """
-    
+
     def __init__(self, wsdl, service):
         """
         @param wsdl: A wsdl object
@@ -59,7 +60,7 @@ class ServiceDefinition:
         self.publictypes()
         self.getprefixes()
         self.pushprefixes()
-    
+
     def pushprefixes(self):
         """
         Add our prefixes to the wsdl so that when users invoke methods
@@ -70,16 +71,16 @@ class ServiceDefinition:
 
     def addports(self):
         """
-        Look through the list of service ports and construct a list of tuples where
-        each tuple is used to describe a port and it's list of methods as:
-        (port, [method]).  Each method is tuple: (name, [pdef,..] where each pdef is
-        a tuple: (param-name, type).
+        Look through the list of service ports and construct a list of tuples
+        where each tuple is used to describe a port and it's list of methods
+        as: (port, [method]).  Each method is tuple: (name, [pdef,..] where
+        each pdef is a tuple: (param-name, type).
         """
         timer = metrics.Timer()
         timer.start()
         for port in self.service.ports:
             p = self.findport(port)
-            for op in list(port.binding.operations.values()):
+            for op in port.binding.operations.values():
                 m = p[0].method(op.name)
                 binding = m.binding.input
                 method = (m.name, binding.param_defs(m))
@@ -87,7 +88,7 @@ class ServiceDefinition:
                 metrics.log.debug("method '%s' created: %s", m.name, timer)
             p[1].sort()
         timer.stop()
-            
+
     def findport(self, port):
         """
         Find and return a port tuple for the specified port.
@@ -98,69 +99,76 @@ class ServiceDefinition:
         @rtype: (port, [method])
         """
         for p in self.ports:
-            if p[0] == p: return p
+            if p[0] == p:
+                return p
         p = (port, [])
         self.ports.append(p)
         return p
-            
+
     def getprefixes(self):
         """
         Add prefixes foreach namespace referenced by parameter types.
         """
         namespaces = []
         for l in (self.params, self.types):
-            for t,r in l:
+            for t, r in l:
                 ns = r.namespace()
-                if ns[1] is None: continue
-                if ns[1] in namespaces: continue
+                if ns[1] is None:
+                    continue
+                if ns[1] in namespaces:
+                    continue
                 if Namespace.xs(ns) or Namespace.xsd(ns):
                     continue
                 namespaces.append(ns[1])
-                if t == r: continue
+                if t == r:
+                    continue
                 ns = t.namespace()
-                if ns[1] is None: continue
-                if ns[1] in namespaces: continue
+                if ns[1] is None:
+                    continue
+                if ns[1] in namespaces:
+                    continue
                 namespaces.append(ns[1])
-        i = 0
         namespaces.sort()
         for u in namespaces:
             p = self.nextprefix()
             ns = (p, u)
             self.prefixes.append(ns)
-            
+
     def paramtypes(self):
         """ get all parameter types """
         for m in [p[1] for p in self.ports]:
             for p in [p[1] for p in m]:
                 for pd in p:
-                    if pd[1] in self.params: continue
+                    if pd[1] in self.params:
+                        continue
                     item = (pd[1], pd[1].resolve())
                     self.params.append(item)
-                    
+
     def publictypes(self):
         """ get all public types """
-        for t in list(self.wsdl.schema.types.values()):
-            if t in self.params: continue
-            if t in self.types: continue
+        for t in self.wsdl.schema.types.values():
+            if t in self.params:
+                continue
+            if t in self.types:
+                continue
             item = (t, t)
             self.types.append(item)
-        tc = lambda x,y: cmp(x[0].name, y[0].name)
-        self.types.sort(cmp=tc)
-        
+        self.types.sort(key=lambda x: x[0].name)
+
     def nextprefix(self):
         """
-        Get the next available prefix.  This means a prefix starting with 'ns' with
-        a number appended as (ns0, ns1, ..) that is not already defined on the
-        wsdl document.
+        Get the next available prefix.  This means a prefix starting with 'ns'
+        with a number appended as (ns0, ns1, ..) that is not already defined
+        on the wsdl document.
         """
         used = [ns[0] for ns in self.prefixes]
-        used += [ns[0] for ns in list(self.wsdl.root.nsprefixes.items())]
-        for n in range(0,1024):
-            p = 'ns%d'%n
+        used += [ns[0] for ns in self.wsdl.root.nsprefixes.items()]
+        for n in range(0, 1024):
+            p = 'ns%d' % n
             if p not in used:
                 return p
         raise Exception('prefixes exhausted')
-    
+
     def getprefix(self, u):
         """
         Get the prefix for the specified namespace (uri)
@@ -170,11 +178,13 @@ class ServiceDefinition:
         @rtype: (prefix, uri).
         """
         for ns in Namespace.all:
-            if u == ns[1]: return ns[0]
+            if u == ns[1]:
+                return ns[0]
         for ns in self.prefixes:
-            if u == ns[1]: return ns[0]
-        raise Exception('ns (%s) not mapped'  % u)
-    
+            if u == ns[1]:
+                return ns[0]
+        raise Exception('ns (%s) not mapped' % u)
+
     def xlate(self, type):
         """
         Get a (namespace) translated I{qualified} name for specified type.
@@ -192,16 +202,23 @@ class ServiceDefinition:
             return name
         prefix = self.getprefix(ns[1])
         return ':'.join((prefix, name))
-        
-    def description(self):
+
+    def description(self, html=False):
         """
-        Get a textual description of the service for which this object represents.
+        Get a textual description of the service for which this object
+        represents.
         @return: A textual description.
         @rtype: str
         """
         s = []
-        indent = (lambda n :  '\n%*s'%(n*3,' '))
-        s.append('Service ( %s ) tns="%s"' % (self.service.name, self.wsdl.tns[1]))
+        if html:
+            indent = lambda n: '<p>%*s' % (n * 3, ' ')
+            line = '<hr/>'
+        else:
+            indent = lambda n: '\n%*s' % (n * 3, ' ')
+            line = '\n' + '-'*80
+        s.append('Service ( %s ) tns="%s"' %
+                 (self.service.name, self.wsdl.tns[1]))
         s.append(indent(1))
         s.append('Prefixes (%d)' % len(self.prefixes))
         for p in self.prefixes:
@@ -234,15 +251,22 @@ class ServiceDefinition:
             for t in self.types:
                 s.append(indent(4))
                 s.append(self.xlate(t[0]))
-        s.append('\n\n')
+        s.append(line)
         return ''.join(s)
-    
+
     def __str__(self):
-        return str(self)
-        
-    def __unicode__(self):
         try:
             return self.description()
         except Exception as e:
             log.exception(e)
-        return tostr(e)
+            return tostr(e)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def html(self):
+        try:
+            return self.description(html=True)
+        except Exception as e:
+            log.exception(e)
+            return tostr(e)

--- a/suds/serviceproxy.py
+++ b/suds/serviceproxy.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -21,17 +21,18 @@ Replaced by: L{client.Client}
 """
 
 from logging import getLogger
-from suds import *
-from suds.client import Client
 
+from .client import Client
+from .compat import unicode
+from .utils import is_builtin
 log = getLogger(__name__)
 
 
 class ServiceProxy(object):
-    
-    """ 
+
+    """
     A lightweight soap based web service proxy.
-    @ivar __client__: A client.  
+    @ivar __client__: A client.
         Everything is delegated to the 2nd generation API.
     @type __client__: L{Client}
     @note:  Deprecated, replaced by L{Client}.
@@ -43,7 +44,8 @@ class ServiceProxy(object):
         @type url: str
         @param kwargs: keyword arguments.
         @keyword faults: Raise faults raised by server (default:True),
-                else return tuple from service method invocation as (http code, object).
+                         else return tuple from service method invocation as
+                         (http code, object).
         @type faults: boolean
         @keyword proxy: An http proxy to be specified on requests (default:{}).
                            The proxy is defined as {protocol:proxy,}
@@ -51,7 +53,7 @@ class ServiceProxy(object):
         """
         client = Client(url, **kwargs)
         self.__client__ = client
-    
+
     def get_instance(self, name):
         """
         Get an instance of a WSDL type by name
@@ -61,7 +63,7 @@ class ServiceProxy(object):
         @rtype: L{sudsobject.Object}
         """
         return self.__client__.factory.create(name)
-    
+
     def get_enum(self, name):
         """
         Get an instance of an enumeration defined in the WSDL by name.
@@ -71,16 +73,15 @@ class ServiceProxy(object):
         @rtype: L{sudsobject.Object}
         """
         return self.__client__.factory.create(name)
- 
+
     def __str__(self):
         return str(self.__client__)
-        
+
     def __unicode__(self):
         return str(self.__client__)
-    
+
     def __getattr__(self, name):
-        builtin =  name.startswith('__') and name.endswith('__')
-        if builtin:
+        if is_builtin(name):
             return self.__dict__[name]
         else:
             return getattr(self.__client__.service, name)

--- a/suds/soaparray.py
+++ b/suds/soaparray.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,8 +19,6 @@ The I{soaparray} module provides XSD extensions for handling
 soap (section 5) encoded arrays.
 """
 
-from suds import *
-from logging import getLogger
 from suds.xsd.sxbasic import Factory as SXFactory
 from suds.xsd.sxbasic import Attribute as SXAttribute
 
@@ -43,12 +41,12 @@ class Attribute(SXAttribute):
             self.aty = aty[:-2]
         else:
             self.aty = aty
-        
+
     def autoqualified(self):
         aqs = SXAttribute.autoqualified(self)
         aqs.append('aty')
         return aqs
-    
+
     def description(self):
         d = SXAttribute.description(self)
         d = d+('aty',)
@@ -58,6 +56,8 @@ class Attribute(SXAttribute):
 # Builder function, only builds Attribute when arrayType
 # attribute is defined on root.
 #
+
+
 def __fn(x, y):
     ns = (None, "http://schemas.xmlsoap.org/wsdl/")
     aty = y.get('arrayType', ns=ns)

--- a/suds/store.py
+++ b/suds/store.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -29,16 +29,17 @@ log = getLogger(__name__)
 #
 # Soap section 5 encoding schema.
 #
-encoding = \
-"""<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://schemas.xmlsoap.org/soap/encoding/">
-        
+encoding = """<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:tns="http://schemas.xmlsoap.org/soap/encoding/"
+    targetNamespace="http://schemas.xmlsoap.org/soap/encoding/">
+
  <xs:attribute name="root">
    <xs:annotation>
      <xs:documentation>
        'root' can be used to distinguish serialization roots from other
        elements that are present in a serialization but are not roots of
-       a serialized value graph 
+       a serialized value graph
      </xs:documentation>
    </xs:annotation>
    <xs:simpleType>
@@ -51,7 +52,7 @@ encoding = \
   <xs:attributeGroup name="commonAttributes">
     <xs:annotation>
       <xs:documentation>
-        Attributes common to all elements that function as accessors or 
+        Attributes common to all elements that function as accessors or
         represent independent (multi-ref) values.  The href attribute is
         intended to be used in a manner like CONREF.  That is, the element
         content should be empty iff the href attribute appears
@@ -63,26 +64,26 @@ encoding = \
   </xs:attributeGroup>
 
   <!-- Global Attributes.  The following attributes are intended to be usable via qualified attribute names on any complex type referencing them. -->
-       
+
   <!-- Array attributes. Needed to give the type and dimensions of an array's contents, and the offset for partially-transmitted arrays. -->
-   
+
   <xs:simpleType name="arrayCoordinate">
     <xs:restriction base="xs:string"/>
   </xs:simpleType>
-          
+
   <xs:attribute name="arrayType" type="xs:string"/>
   <xs:attribute name="offset" type="tns:arrayCoordinate"/>
-  
+
   <xs:attributeGroup name="arrayAttributes">
     <xs:attribute ref="tns:arrayType"/>
     <xs:attribute ref="tns:offset"/>
-  </xs:attributeGroup>    
-  
-  <xs:attribute name="position" type="tns:arrayCoordinate"/> 
-  
+  </xs:attributeGroup>
+
+  <xs:attribute name="position" type="tns:arrayCoordinate"/>
+
   <xs:attributeGroup name="arrayMemberAttributes">
     <xs:attribute ref="tns:position"/>
-  </xs:attributeGroup>    
+  </xs:attributeGroup>
 
   <xs:group name="Array">
     <xs:sequence>
@@ -94,18 +95,18 @@ encoding = \
   <xs:complexType name="Array">
     <xs:annotation>
       <xs:documentation>
-       'Array' is a complex type for accessors identified by position 
+       'Array' is a complex type for accessors identified by position
       </xs:documentation>
     </xs:annotation>
     <xs:group ref="tns:Array" minOccurs="0"/>
     <xs:attributeGroup ref="tns:arrayAttributes"/>
     <xs:attributeGroup ref="tns:commonAttributes"/>
-  </xs:complexType> 
+  </xs:complexType>
 
-  <!-- 'Struct' is a complex type for accessors identified by name. 
+  <!-- 'Struct' is a complex type for accessors identified by name.
        Constraint: No element may be have the same name as any other,
        nor may any element have a maxOccurs > 1. -->
-   
+
   <xs:element name="Struct" type="tns:Struct"/>
 
   <xs:group name="Struct">
@@ -117,7 +118,7 @@ encoding = \
   <xs:complexType name="Struct">
     <xs:group ref="tns:Struct" minOccurs="0"/>
     <xs:attributeGroup ref="tns:commonAttributes"/>
-  </xs:complexType> 
+  </xs:complexType>
 
   <!-- 'Base64' can be used to serialize binary data using base64 encoding
        as defined in RFC2045 but without the MIME line length limitation. -->
@@ -126,7 +127,7 @@ encoding = \
     <xs:restriction base="xs:base64Binary"/>
   </xs:simpleType>
 
- <!-- Element declarations corresponding to each of the simple types in the 
+ <!-- Element declarations corresponding to each of the simple types in the
       XML Schemas Specification. -->
 
   <xs:element name="duration" type="tns:duration"/>
@@ -157,7 +158,7 @@ encoding = \
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
-  
+
 
   <xs:element name="time" type="tns:time"/>
   <xs:complexType name="time">
@@ -221,7 +222,7 @@ encoding = \
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
-  
+
   <xs:element name="boolean" type="tns:boolean"/>
   <xs:complexType name="boolean">
     <xs:simpleContent>
@@ -285,7 +286,7 @@ encoding = \
     </xs:simpleContent>
   </xs:complexType>
 
-  
+
   <xs:element name="string" type="tns:string"/>
   <xs:complexType name="string">
     <xs:simpleContent>
@@ -543,13 +544,13 @@ class DocumentStore:
     @cvar store: The mapping of URL location to documents.
     @type store: dict
     """
-    
+
     protocol = 'suds'
-    
+
     store = {
-        'schemas.xmlsoap.org/soap/encoding/' : encoding
+        'schemas.xmlsoap.org/soap/encoding/': encoding
     }
-    
+
     def open(self, url):
         """
         Open a document at the specified url.
@@ -563,7 +564,7 @@ class DocumentStore:
             return self.find(location)
         else:
             return None
-        
+
     def find(self, location):
         """
         Find the specified location in the store.
@@ -578,7 +579,7 @@ class DocumentStore:
         except:
             reason = 'location "%s" not in document store' % location
             raise Exception(reason)
-        
+
     def split(self, url):
         """
         Split the url into I{protocol} and I{location}

--- a/suds/sudsobject.py
+++ b/suds/sudsobject.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -21,7 +21,10 @@ wsdl/xsd defined types.
 """
 
 from logging import getLogger
-from suds import *
+
+from . import tostr
+from .compat import basestring
+from .utils import is_builtin
 
 log = getLogger(__name__)
 
@@ -50,6 +53,7 @@ def asdict(sobject):
     """
     return dict(items(sobject))
 
+
 def merge(a, b):
     """
     Merge all attributes and metadata from I{a} to I{b}.
@@ -63,10 +67,12 @@ def merge(a, b):
         b.__metadata__ = b.__metadata__
     return b
 
+
 def footprint(sobject):
     """
     Get the I{virtual footprint} of the object.
-    This is really a count of the attributes in the branch with a significant value.
+    This is really a count of the attributes in the branch with a significant
+    value.
     @param sobject: A suds object.
     @type sobject: L{Object}
     @return: The branch footprint.
@@ -75,21 +81,23 @@ def footprint(sobject):
     n = 0
     for a in sobject.__keylist__:
         v = getattr(sobject, a)
-        if v is None: continue
+        if v is None:
+            continue
         if isinstance(v, Object):
             n += footprint(v)
             continue
         if hasattr(v, '__len__'):
-            if len(v): n += 1
+            if len(v):
+                n += 1
             continue
-        n +=1
+        n += 1
     return n
 
-    
+
 class Factory:
-    
+
     cache = {}
-    
+
     @classmethod
     def subclass(cls, name, bases, dict={}):
         if not isinstance(bases, tuple):
@@ -97,10 +105,10 @@ class Factory:
         key = '.'.join((name, str(bases)))
         subclass = cls.cache.get(key)
         if subclass is None:
-            subclass = classobj(name, bases, dict)
+            subclass = type(name, bases, dict)
             cls.cache[key] = subclass
         return subclass
-    
+
     @classmethod
     def object(cls, classname=None, dict={}):
         if classname is not None:
@@ -108,14 +116,14 @@ class Factory:
             inst = subclass()
         else:
             inst = Object()
-        for a in list(dict.items()):
+        for a in dict.items():
             setattr(inst, a[0], a[1])
         return inst
-    
+
     @classmethod
     def metadata(cls):
         return Metadata()
-    
+
     @classmethod
     def property(cls, name, value=None):
         subclass = cls.subclass(name, Property)
@@ -130,17 +138,14 @@ class Object:
         self.__metadata__ = Metadata()
 
     def __setattr__(self, name, value):
-        builtin =  name.startswith('__') and name.endswith('__')
-        if not builtin and \
-            name not in self.__keylist__:
+        if not is_builtin(name) and name not in self.__keylist__:
             self.__keylist__.append(name)
         self.__dict__[name] = value
-        
+
     def __delattr__(self, name):
         try:
             del self.__dict__[name]
-            builtin =  name.startswith('__') and name.endswith('__')
-            if not builtin:
+            if not is_builtin(name):
                 self.__keylist__.remove(name)
         except:
             cls = self.__class__.__name__
@@ -150,25 +155,22 @@ class Object:
         if isinstance(name, int):
             name = self.__keylist__[int(name)]
         return getattr(self, name)
-    
+
     def __setitem__(self, name, value):
         setattr(self, name, value)
-        
+
     def __iter__(self):
         return Iter(self)
 
     def __len__(self):
         return len(self.__keylist__)
-    
+
     def __contains__(self, name):
         return name in self.__keylist__
-    
-    def __repr__(self):
-        return str(self)
 
     def __str__(self):
-        return str(self)
-    
+        return self.__printer__.tostr(self)
+
     def __unicode__(self):
         return self.__printer__.tostr(self)
 
@@ -181,6 +183,9 @@ class Iter:
         self.index = 0
 
     def __next__(self):
+        return self.next()
+
+    def next(self):
         keylist = self.keylist
         nkeys = len(self.keylist)
         while self.index < nkeys:
@@ -190,7 +195,7 @@ class Iter:
                 v = getattr(self.sobject, k)
                 return (k, v)
         raise StopIteration()
-    
+
     def __keylist(self, sobject):
         keylist = sobject.__keylist__
         try:
@@ -200,13 +205,13 @@ class Iter:
             if not ordered.issuperset(keyset):
                 log.debug(
                     '%s must be superset of %s, ordering ignored',
-                    keylist, 
+                    keylist,
                     ordering)
                 raise KeyError()
             return ordering
         except:
             return keylist
-        
+
     def __iter__(self):
         return self
 
@@ -223,39 +228,40 @@ class Facade(Object):
         md = self.__metadata__
         md.facade = name
 
-       
+
 class Property(Object):
 
     def __init__(self, value):
         Object.__init__(self)
         self.value = value
-        
+
     def items(self):
         for item in self:
             if item[0] != 'value':
                 yield item
-        
+
     def get(self):
         return self.value
-    
+
     def set(self, value):
         self.value = value
         return self
 
 
 class Printer:
-    """ 
+    """
     Pretty printing of a Object object.
     """
-    
+
     @classmethod
-    def indent(cls, n): return '%*s'%(n*3,' ')
+    def indent(cls, n):
+        return '%*s' % (n * 3, ' ')
 
     def tostr(self, object, indent=-2):
         """ get s string representation of object """
         history = []
         return self.process(object, history, indent)
-    
+
     def process(self, object, h, n=0, nl=False):
         """ print object using the specified indent (n) and newline (nl). """
         if object is None:
@@ -270,15 +276,15 @@ class Printer:
                 return '<empty>'
             else:
                 return self.print_dictionary(object, h, n+2, nl)
-        if isinstance(object, (list,tuple)):
+        if isinstance(object, (list, tuple)):
             if len(object) == 0:
                 return '<empty>'
             else:
                 return self.print_collection(object, h, n+2)
-        if isinstance(object, str):
+        if isinstance(object, basestring):
             return '"%s"' % tostr(object)
         return '%s' % tostr(object)
-    
+
     def print_object(self, d, h, n, nl=False):
         """ print complex using the specified indent (n) and newline (nl). """
         s = []
@@ -308,7 +314,7 @@ class Printer:
             item = self.unwrap(d, item)
             s.append('\n')
             s.append(self.indent(n+1))
-            if isinstance(item[1], (list,tuple)):            
+            if isinstance(item[1], (list, tuple)):
                 s.append(item[0])
                 s.append('[]')
             else:
@@ -320,20 +326,21 @@ class Printer:
         s.append('}')
         h.pop()
         return ''.join(s)
-    
+
     def print_dictionary(self, d, h, n, nl=False):
         """ print complex using the specified indent (n) and newline (nl). """
-        if d in h: return '{}...'
+        if d in h:
+            return '{}...'
         h.append(d)
         s = []
         if nl:
             s.append('\n')
             s.append(self.indent(n))
         s.append('{')
-        for item in list(d.items()):
+        for item in d.items():
             s.append('\n')
             s.append(self.indent(n+1))
-            if isinstance(item[1], (list,tuple)):            
+            if isinstance(item[1], (list, tuple)):
                 s.append(tostr(item[0]))
                 s.append('[]')
             else:
@@ -347,8 +354,9 @@ class Printer:
         return ''.join(s)
 
     def print_collection(self, c, h, n):
-        """ print collection using the specified indent (n) and newline (nl). """
-        if c in h: return '[]...'
+        """print collection using the specified indent (n) and newline (nl)."""
+        if c in h:
+            return '[]...'
         h.append(c)
         s = []
         for item in c:
@@ -358,10 +366,10 @@ class Printer:
             s.append(',')
         h.pop()
         return ''.join(s)
-    
+
     def unwrap(self, d, item):
         """ translate (unwrap) using an optional wrapper function """
-        nopt = ( lambda x: x )
+        nopt = lambda x: x
         try:
             md = d.__metadata__
             pmd = getattr(md, '__print__', None)
@@ -373,7 +381,7 @@ class Printer:
         except:
             pass
         return item
-    
+
     def exclude(self, d, item):
         """ check metadata for excluded items """
         try:
@@ -382,7 +390,7 @@ class Printer:
             if pmd is None:
                 return False
             excludes = getattr(pmd, 'excludes', [])
-            return ( item[0] in excludes ) 
+            return item[0] in excludes
         except:
             pass
         return False

--- a/suds/transport/__init__.py
+++ b/suds/transport/__init__.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -25,6 +25,7 @@ class TransportError(Exception):
         self.httpcode = httpcode
         self.fp = fp
 
+
 class Request:
     """
     A transport request
@@ -46,13 +47,13 @@ class Request:
         self.url = url
         self.headers = {}
         self.message = message
-        
+
     def __str__(self):
         s = []
         s.append('URL:%s' % self.url)
         s.append('HEADERS: %s' % self.headers)
         s.append('MESSAGE:')
-        s.append(self.message)
+        s.append(str(self.message))
         return '\n'.join(s)
 
 
@@ -79,13 +80,13 @@ class Reply:
         self.code = code
         self.headers = headers
         self.message = message
-        
+
     def __str__(self):
         s = []
         s.append('CODE: %s' % self.code)
         s.append('HEADERS: %s' % self.headers)
         s.append('MESSAGE:')
-        s.append(self.message)
+        s.append(str(self.message))
         return '\n'.join(s)
 
 
@@ -93,7 +94,7 @@ class Transport:
     """
     The transport I{interface}.
     """
-    
+
     def __init__(self):
         """
         Constructor.
@@ -101,7 +102,7 @@ class Transport:
         from suds.transport.options import Options
         self.options = Options()
         del Options
-    
+
     def open(self, request):
         """
         Open the url in the specified request.
@@ -112,7 +113,7 @@ class Transport:
         @raise TransportError: On all transport errors.
         """
         raise Exception('not-implemented')
-    
+
     def send(self, request):
         """
         Send soap message.  Implementations are expected to handle:

--- a/suds/transport/http.py
+++ b/suds/transport/http.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -18,12 +18,12 @@
 Contains classes for basic HTTP transport implementations.
 """
 
-import urllib.request, urllib.error, urllib.parse
-import base64
+import urllib.request as u2
+from urllib.error import HTTPError
+from base64 import b64encode
 import socket
-from suds.transport import *
+from suds.transport import Transport, TransportError, Reply
 from suds.properties import Unskin
-from urllib.parse import urlparse
 from http.cookiejar import CookieJar
 from logging import getLogger
 
@@ -35,7 +35,7 @@ class HttpTransport(Transport):
     HTTP transport using urllib2.  Provided basic http transport
     that provides for cookies, proxies but no authentication.
     """
-    
+
     def __init__(self, **kwargs):
         """
         @param kwargs: Keyword arguments.
@@ -52,15 +52,16 @@ class HttpTransport(Transport):
         self.cookiejar = CookieJar()
         self.proxy = {}
         self.urlopener = None
-        
+
     def open(self, request):
         try:
             url = request.url
+            headers = request.headers
             log.debug('opening (%s)', url)
-            u2request = urllib.request.Request(url)
+            u2request = u2.Request(url, None, headers)
             self.proxy = self.options.proxy
             return self.u2open(u2request)
-        except urllib.error.HTTPError as e:
+        except HTTPError as e:
             raise TransportError(str(e), e.code, e.fp)
 
     def send(self, request):
@@ -69,17 +70,17 @@ class HttpTransport(Transport):
         msg = request.message
         headers = request.headers
         try:
-            u2request = urllib.request.Request(url, msg, headers)
+            u2request = u2.Request(url, msg, headers)
             self.addcookies(u2request)
             self.proxy = self.options.proxy
             request.headers.update(u2request.headers)
             log.debug('sending:\n%s', request)
             fp = self.u2open(u2request)
             self.getcookies(fp, u2request)
-            result = Reply(200, fp.headers.dict, fp.read())
+            result = Reply(200, fp.headers, fp.read())
             log.debug('received:\n%s', result)
-        except urllib.error.HTTPError as e:
-            if e.code in (202,204):
+        except HTTPError as e:
+            if e.code in (202, 204):
                 result = None
             else:
                 raise TransportError(e.msg, e.code, e.fp)
@@ -92,7 +93,7 @@ class HttpTransport(Transport):
         @rtype: u2request: urllib2.Requet.
         """
         self.cookiejar.add_cookie_header(u2request)
-        
+
     def getcookies(self, fp, u2request):
         """
         Add cookies in the request to the cookiejar.
@@ -100,7 +101,7 @@ class HttpTransport(Transport):
         @rtype: u2request: urllib2.Requet.
         """
         self.cookiejar.extract_cookies(fp, u2request)
-        
+
     def u2open(self, u2request):
         """
         Open a connection.
@@ -116,7 +117,7 @@ class HttpTransport(Transport):
             return url.open(u2request)
         else:
             return url.open(u2request, timeout=tm)
-            
+
     def u2opener(self):
         """
         Create a urllib opener.
@@ -124,10 +125,10 @@ class HttpTransport(Transport):
         @rtype: I{OpenerDirector}
         """
         if self.urlopener is None:
-            return urllib.request.build_opener(*self.u2handlers())
+            return u2.build_opener(*self.u2handlers())
         else:
             return self.urlopener
-        
+
     def u2handlers(self):
         """
         Get a collection of urllib handlers.
@@ -135,9 +136,9 @@ class HttpTransport(Transport):
         @rtype: [Handler,...]
         """
         handlers = []
-        handlers.append(urllib.request.ProxyHandler(self.proxy))
+        handlers.append(u2.ProxyHandler(self.proxy))
         return handlers
-            
+
     def u2ver(self):
         """
         Get the major/minor version of the urllib2 lib.
@@ -145,13 +146,13 @@ class HttpTransport(Transport):
         @rtype: float
         """
         try:
-            part = urllib2.__version__.split('.', 1)
+            part = u2.__version__.split('.', 1)
             n = float('.'.join(part))
             return n
         except Exception as e:
             log.exception(e)
             return 0
-        
+
     def __deepcopy__(self, memo={}):
         clone = self.__class__()
         p = Unskin(self.options)
@@ -167,21 +168,21 @@ class HttpAuthenticated(HttpTransport):
     appends the I{Authorization} http header with base64 encoded
     credentials on every http request.
     """
-    
+
     def open(self, request):
         self.addcredentials(request)
         return HttpTransport.open(self, request)
-    
+
     def send(self, request):
         self.addcredentials(request)
         return HttpTransport.send(self, request)
-    
+
     def addcredentials(self, request):
         credentials = self.credentials()
         if not (None in credentials):
-            encoded = base64.encodestring(':'.join(credentials))
-            basic = 'Basic %s' % encoded[:-1]
+            encoded = b64encode(':'.join(credentials).encode('utf-8')).decode("ascii")
+            basic = 'Basic %s' % encoded
             request.headers['Authorization'] = basic
-                 
+
     def credentials(self):
         return (self.options.username, self.options.password)

--- a/suds/transport/https.py
+++ b/suds/transport/https.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -18,10 +18,11 @@
 Contains classes for basic HTTP (authenticated) transport implementations.
 """
 
-import urllib.request, urllib.error, urllib.parse
-from suds.transport import *
 from suds.transport.http import HttpTransport
 from logging import getLogger
+from urllib.request import (
+    HTTPPasswordMgrWithDefaultRealm,
+    HTTPBasicAuthHandler)
 
 log = getLogger(__name__)
 
@@ -34,7 +35,7 @@ class HttpAuthenticated(HttpTransport):
     @ivar pm: The password manager.
     @ivar handler: The authentication handler.
     """
-    
+
     def __init__(self, **kwargs):
         """
         @param kwargs: Keyword arguments.
@@ -53,32 +54,32 @@ class HttpAuthenticated(HttpTransport):
                     - default: None
         """
         HttpTransport.__init__(self, **kwargs)
-        self.pm = urllib.request.HTTPPasswordMgrWithDefaultRealm()
-        
+        self.pm = HTTPPasswordMgrWithDefaultRealm()
+
     def open(self, request):
         self.addcredentials(request)
-        return  HttpTransport.open(self, request)
-    
+        return HttpTransport.open(self, request)
+
     def send(self, request):
         self.addcredentials(request)
-        return  HttpTransport.send(self, request)
-    
+        return HttpTransport.send(self, request)
+
     def addcredentials(self, request):
         credentials = self.credentials()
         if not (None in credentials):
             u = credentials[0]
             p = credentials[1]
             self.pm.add_password(None, request.url, u, p)
-    
+
     def credentials(self):
         return (self.options.username, self.options.password)
-    
+
     def u2handlers(self):
             handlers = HttpTransport.u2handlers(self)
-            handlers.append(urllib.request.HTTPBasicAuthHandler(self.pm))
+            handlers.append(HTTPBasicAuthHandler(self.pm))
             return handlers
-    
-    
+
+
 class WindowsHttpAuthenticated(HttpAuthenticated):
     """
     Provides Windows (NTLM) http authentication.
@@ -86,13 +87,13 @@ class WindowsHttpAuthenticated(HttpAuthenticated):
     @ivar handler: The authentication handler.
     @author: Christopher Bess
     """
-        
+
     def u2handlers(self):
-        # try to import ntlm support  
+        # try to import ntlm support
         try:
-            from ntlm import HTTPNtlmAuthHandler
+            from ntlm3 import HTTPNtlmAuthHandler
         except ImportError:
-            raise Exception("Cannot import python-ntlm module")
+            raise Exception("Cannot import python-ntlm3 module")
         handlers = HttpTransport.u2handlers(self)
         handlers.append(HTTPNtlmAuthHandler.HTTPNtlmAuthHandler(self.pm))
         return handlers

--- a/suds/transport/options.py
+++ b/suds/transport/options.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,10 +19,9 @@ Contains classes for transport options.
 """
 
 
-from suds.transport import *
-from suds.properties import *
+from suds.properties import Skin, Definition
 
-   
+
 class Options(Skin):
     """
     Options:
@@ -44,12 +43,12 @@ class Options(Skin):
         - B{password} - The password used for http authentication.
                 - type: I{str}
                 - default: None
-    """    
+    """
     def __init__(self, **kwargs):
         domain = __name__
         definitions = [
             Definition('proxy', dict, {}),
-            Definition('timeout', (int,float), 90),
+            Definition('timeout', (int, float), 90),
             Definition('headers', dict, {}),
             Definition('username', str, None),
             Definition('password', str, None),

--- a/suds/umx/__init__.py
+++ b/suds/umx/__init__.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -22,7 +22,6 @@ unmarshalling (XML).
 from suds.sudsobject import Object
 
 
-
 class Content(Object):
     """
     @ivar node: The content source node.
@@ -32,7 +31,7 @@ class Content(Object):
     @ivar text: The (optional) content (xml) text.
     @type text: basestring
     """
-    
+
     extensions = []
 
     def __init__(self, node, **kwargs):
@@ -40,7 +39,7 @@ class Content(Object):
         self.node = node
         self.data = None
         self.text = None
-        for k,v in list(kwargs.items()):
+        for k, v in kwargs.items():
             setattr(self, k, v)
 
     def __getattr__(self, name):

--- a/suds/umx/attrlist.py
+++ b/suds/umx/attrlist.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -18,8 +18,6 @@
 Provides filtered attribute list classes.
 """
 
-from suds import *
-from suds.umx import *
 from suds.sax import Namespace
 
 
@@ -37,7 +35,7 @@ class AttrList:
         @type attributes: list
         """
         self.raw = attributes
-        
+
     def real(self):
         """
         Get list of I{real} attributes which exclude xs and xml attributes.
@@ -45,20 +43,22 @@ class AttrList:
         @rtype: I{generator}
         """
         for a in self.raw:
-            if self.skip(a): continue
+            if self.skip(a):
+                continue
             yield a
-            
+
     def rlen(self):
         """
-        Get the number of I{real} attributes which exclude xs and xml attributes.
-        @return: A count of I{real} attributes. 
+        Get the number of I{real} attributes which exclude xs and xml
+        attributes.
+        @return: A count of I{real} attributes.
         @rtype: L{int}
         """
         n = 0
         for a in self.real():
             n += 1
         return n
-            
+
     def lang(self):
         """
         Get list of I{filtered} attributes which exclude xs.
@@ -85,4 +85,4 @@ class AttrList:
             'http://schemas.xmlsoap.org/soap/envelope/',
             'http://www.w3.org/2003/05/soap-envelope',
         )
-        return ( Namespace.xs(ns) or ns[1] in skip )
+        return Namespace.xs(ns) or ns[1] in skip

--- a/suds/umx/basic.py
+++ b/suds/umx/basic.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -18,9 +18,7 @@
 Provides basic unmarshaller classes.
 """
 
-from logging import getLogger
-from suds import *
-from suds.umx import *
+from suds.umx import Content
 from suds.umx.core import Core
 
 
@@ -28,7 +26,7 @@ class Basic(Core):
     """
     A object builder (unmarshaller).
     """
-        
+
     def process(self, node):
         """
         Process an object graph representation of the xml I{node}.

--- a/suds/umx/core.py
+++ b/suds/umx/core.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,8 +19,8 @@ Provides base classes for XML->object I{unmarshalling}.
 """
 
 from logging import getLogger
-from suds import *
-from suds.umx import *
+from suds.compat import basestring
+from suds.umx import Content
 from suds.umx.attrlist import AttrList
 from suds.sax.text import Text
 from suds.sudsobject import Factory, merge
@@ -28,14 +28,18 @@ from suds.sudsobject import Factory, merge
 
 log = getLogger(__name__)
 
-reserved = { 'class':'cls', 'def':'dfn', }
+reserved = {
+    'class': 'cls',
+    'def': 'dfn',
+}
+
 
 class Core:
     """
     The abstract XML I{node} unmarshaller.  This class provides the
     I{core} unmarshalling functionality.
     """
-        
+
     def process(self, content):
         """
         Process an object graph representation of the xml I{node}.
@@ -46,7 +50,7 @@ class Core:
         """
         self.reset()
         return self.append(content)
-    
+
     def append(self, content):
         """
         Process the specified node and convert the XML document into
@@ -64,15 +68,17 @@ class Core:
         self.append_text(content)
         self.end(content)
         return self.postprocess(content)
-            
+
     def postprocess(self, content):
         """
         Perform final processing of the resulting data structure as follows:
-          - Mixed values (children and text) will have a result of the I{content.node}.
-          - Simi-simple values (attributes, no-children and text) will have a result of a
-             property object.
-          - Simple values (no-attributes, no-children with text nodes) will have a string 
-             result equal to the value of the content.node.getText().
+          - Mixed values (children and text) will have a result of the
+             I{content.node}.
+          - Semi-simple values (attributes, no-children and text) will have a
+             result of a property object.
+          - Simple values (no-attributes, no-children with text nodes) will
+             have a string result equal to the value of the
+             content.node.getText().
         @param content: The current content being unmarshalled.
         @type content: L{Content}
         @return: The post-processed result.
@@ -82,9 +88,11 @@ class Core:
         if len(node.children) and node.hasText():
             return node
         attributes = AttrList(node.attributes)
-        if attributes.rlen() and \
-            not len(node.children) and \
-            node.hasText():
+        if (
+            attributes.rlen() and
+            not len(node.children) and
+            node.hasText()
+        ):
                 p = Factory.property(node.name, node.getText())
                 return merge(content.data, p)
         if len(content.data):
@@ -97,11 +105,11 @@ class Core:
                 return None
             else:
                 return Text('', lang=lang)
-        if isinstance(content.text, str):
+        if isinstance(content.text, basestring):
             return Text(content.text, lang=lang)
         else:
             return content.text
-    
+
     def append_attributes(self, content):
         """
         Append attribute nodes into L{Content.data}.
@@ -114,7 +122,7 @@ class Core:
             name = attr.name
             value = attr.value
             self.append_attribute(name, value, content)
-            
+
     def append_attribute(self, name, value, content):
         """
         Append an attribute name/value into L{Content.data}.
@@ -128,7 +136,7 @@ class Core:
         key = name
         key = '_%s' % reserved.get(key, key)
         setattr(content.data, key, value)
-            
+
     def append_children(self, content):
         """
         Append child nodes into L{Content.data}
@@ -150,10 +158,10 @@ class Core:
                 if cval is None:
                     setattr(content.data, key, [])
                 else:
-                    setattr(content.data, key, [cval,])
+                    setattr(content.data, key, [cval, ])
             else:
                 setattr(content.data, key, cval)
-    
+
     def append_text(self, content):
         """
         Append text nodes into L{Content.data}
@@ -162,7 +170,7 @@ class Core:
         """
         if content.node.hasText():
             content.text = content.node.getText()
-        
+
     def reset(self):
         pass
 
@@ -176,7 +184,7 @@ class Core:
         @rtype: L{Object}
         """
         content.data = Factory.object(content.node.name)
-    
+
     def end(self, content):
         """
         Processing on I{node} has ended.
@@ -184,7 +192,7 @@ class Core:
         @type content: L{Content}
         """
         pass
-    
+
     def bounded(self, content):
         """
         Get whether the content is bounded (not a list).
@@ -193,8 +201,8 @@ class Core:
         @return: True if bounded, else False
         @rtype: boolean
         '"""
-        return ( not self.unbounded(content) )
-    
+        return not self.unbounded(content)
+
     def unbounded(self, content):
         """
         Get whether the object is unbounded (a list).
@@ -204,7 +212,7 @@ class Core:
         @rtype: boolean
         '"""
         return False
-    
+
     def nillable(self, content):
         """
         Get whether the object is nillable.

--- a/suds/umx/encoded.py
+++ b/suds/umx/encoded.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,10 +19,9 @@ Provides soap encoded unmarshaller classes.
 """
 
 from logging import getLogger
-from suds import *
-from suds.umx import *
+from suds.umx import Content
 from suds.umx.typed import Typed
-from suds.sax import splitPrefix, Namespace
+from suds.sax import Namespace
 
 log = getLogger(__name__)
 
@@ -45,7 +44,7 @@ class Encoded(Typed):
         #
         self.setaty(content)
         Typed.start(self, content)
-    
+
     def end(self, content):
         #
         # Squash soap encoded arrays into python lists.  This is
@@ -56,7 +55,7 @@ class Encoded(Typed):
         if aty is not None:
             self.promote(content)
         return Typed.end(self, content)
-    
+
     def postprocess(self, content):
         #
         # Ensure proper rendering of empty arrays.
@@ -65,7 +64,7 @@ class Encoded(Typed):
             return Typed.postprocess(self, content)
         else:
             return content.data
-    
+
     def setaty(self, content):
         """
         Grab the (aty) soap-enc:arrayType and attach it to the
@@ -85,13 +84,13 @@ class Encoded(Typed):
             if len(parts) == 2:
                 self.applyaty(content, ref)
             else:
-                pass # (2) dimensional array
+                pass  # (2) dimensional array
         return self
-    
+
     def applyaty(self, content, xty):
         """
         Apply the type referenced in the I{arrayType} to the content
-        (child nodes) of the array.  Each element (node) in the array 
+        (child nodes) of the array.  Each element (node) in the array
         that does not have an explicit xsi:type attribute is given one
         based on the I{arrayType}.
         @param content: An array content.
@@ -115,13 +114,13 @@ class Encoded(Typed):
     def promote(self, content):
         """
         Promote (replace) the content.data with the first attribute
-        of the current content.data that is a I{list}.  Note: the 
+        of the current content.data that is a I{list}.  Note: the
         content.data may be empty or contain only _x attributes.
         In either case, the content.data is assigned an empty list.
         @param content: An array content.
         @type content: L{Content}
         """
-        for n,v in content.data:
+        for n, v in content.data:
             if isinstance(v, list):
                 content.data = v
                 return

--- a/suds/umx/typed.py
+++ b/suds/umx/typed.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,8 +19,8 @@ Provides typed unmarshaller classes.
 """
 
 from logging import getLogger
-from suds import *
-from suds.umx import *
+from suds import TypeNotFound
+from suds.umx import Content
 from suds.umx.core import Core
 from suds.resolver import NodeResolver, Frame
 from suds.sudsobject import Factory
@@ -43,14 +43,14 @@ class Typed(Core):
     @ivar resolver: A schema type resolver.
     @type resolver: L{NodeResolver}
     """
-    
+
     def __init__(self, schema):
         """
         @param schema: A schema object.
         @type schema: L{xsd.schema.Schema}
         """
         self.resolver = NodeResolver(schema)
-        
+
     def process(self, node, type):
         """
         Process an object graph representation of the xml L{node}.
@@ -68,7 +68,7 @@ class Typed(Core):
     def reset(self):
         log.debug('reset')
         self.resolver.reset()
-    
+
     def start(self, content):
         #
         # Resolve to the schema type; build an object and setup metadata.
@@ -91,18 +91,20 @@ class Typed(Core):
         content.data = Factory.object(cls_name)
         md = content.data.__metadata__
         md.sxtype = real
-        
+
     def end(self, content):
         self.resolver.pop()
-        
+
     def unbounded(self, content):
         return content.type.unbounded()
-    
+
     def nillable(self, content):
         resolved = content.type.resolve()
-        return ( content.type.nillable or \
-            (resolved.builtin() and resolved.nillable ) )
-    
+        return (
+            content.type.nillable or
+            (resolved.builtin() and resolved.nillable)
+        )
+
     def append_attribute(self, name, value, content):
         """
         Append an attribute name/value into L{Content.data}.
@@ -115,11 +117,11 @@ class Typed(Core):
         """
         type = self.resolver.findattr(name)
         if type is None:
-            log.warning('attribute (%s) type, not-found', name)
+            log.warn('attribute (%s) type, not-found', name)
         else:
             value = self.translated(value, type)
         Core.append_attribute(self, name, value, content)
-    
+
     def append_text(self, content):
         """
         Append text nodes into L{Content.data}
@@ -131,7 +133,7 @@ class Typed(Core):
         Core.append_text(self, content)
         known = self.resolver.top().resolved
         content.text = self.translated(content.text, known)
-            
+
     def translated(self, value, type):
         """ translate using the schema type """
         if value is not None:

--- a/suds/utils.py
+++ b/suds/utils.py
@@ -1,0 +1,3 @@
+
+def is_builtin(name):
+    return name.startswith('__') and name.endswith('__')

--- a/suds/wsdl.py
+++ b/suds/wsdl.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -21,8 +21,7 @@ found in the document.
 """
 
 from logging import getLogger
-from suds import *
-from suds.sax import splitPrefix
+from suds import objid, TypeNotFound, MethodNotFound
 from suds.sax.element import Element
 from suds.bindings.document import Document
 from suds.bindings.rpc import RPC, Encoded
@@ -30,10 +29,9 @@ from suds.xsd import qualify, Namespace
 from suds.xsd.schema import Schema, SchemaCollection
 from suds.xsd.query import ElementQuery
 from suds.sudsobject import Object, Facade, Metadata
-from suds.reader import DocumentReader, DefinitionsReader
+from suds.reader import DocumentReader
 from urllib.parse import urljoin
 import re
-from . import soaparray
 
 log = getLogger(__name__)
 
@@ -48,7 +46,7 @@ class WObject(Object):
     @ivar root: The XML I{root} element.
     @type root: L{Element}
     """
-    
+
     def __init__(self, root, definitions=None):
         """
         @param root: An XML root element.
@@ -62,7 +60,7 @@ class WObject(Object):
         pmd.excludes = ['root']
         pmd.wrappers = dict(qname=repr)
         self.__metadata__.__print__ = pmd
-        
+
     def resolve(self, definitions):
         """
         Resolve named references to other WSDL objects.
@@ -71,7 +69,7 @@ class WObject(Object):
         """
         pass
 
-        
+
 class NamedObject(WObject):
     """
     A B{named} WSDL object.
@@ -122,7 +120,7 @@ class Definitions(WObject):
     @ivar service: The service object.
     @type service: L{Service}
     """
-    
+
     Tag = 'definitions'
 
     def __init__(self, url, options):
@@ -162,7 +160,7 @@ class Definitions(WObject):
         for s in self.services:
             self.add_methods(s)
         log.debug("wsdl at '%s' loaded:\n%s", url, self)
-        
+
     def mktns(self, root):
         """ Get/create the target namespace """
         tns = root.get('targetNamespace')
@@ -171,12 +169,13 @@ class Definitions(WObject):
             log.debug('warning: tns (%s), not mapped to prefix', tns)
             prefix = 'tns'
         return (prefix, tns)
-        
+
     def add_children(self, root):
         """ Add child objects using the factory """
         for c in root.getChildren(ns=wsdlns):
             child = Factory.create(c, self)
-            if child is None: continue
+            if child is None:
+                continue
             self.children.append(child)
             if isinstance(child, Import):
                 self.imports.append(child)
@@ -196,17 +195,17 @@ class Definitions(WObject):
             if isinstance(child, Service):
                 self.services.append(child)
                 continue
-                
+
     def open_imports(self):
         """ Import the I{imported} WSDLs. """
         for imp in self.imports:
             imp.load(self)
-                
+
     def resolve(self):
         """ Tell all children to resolve themselves """
         for c in self.children:
             c.resolve(self)
-                
+
     def build_schema(self):
         """ Process L{Types} objects and create the schema collection """
         container = SchemaCollection(self)
@@ -214,7 +213,7 @@ class Definitions(WObject):
             for root in t.contents():
                 schema = Schema(root, self.url, self.options, container)
                 container.add(schema)
-        if not len(container): # empty
+        if not len(container):  # empty
             root = Element.buildPath(self.root, 'types/schema')
             schema = Schema(root, self.url, self.options, container)
             container.add(schema)
@@ -222,18 +221,18 @@ class Definitions(WObject):
         for s in [t.schema() for t in self.types if t.imported()]:
             self.schema.merge(s)
         return self.schema
-                
+
     def add_methods(self, service):
         """ Build method view for service """
         bindings = {
-            'document/literal' : Document(self),
-            'rpc/literal' : RPC(self),
-            'rpc/encoded' : Encoded(self)
+            'document/literal': Document(self),
+            'rpc/literal': RPC(self),
+            'rpc/encoded': Encoded(self)
         }
         for p in service.ports:
             binding = p.binding
             ptype = p.binding.type
-            operations = list(p.binding.type.operations.values())
+            operations = p.binding.type.operations.values()
             for name in [op.name for op in operations]:
                 m = Facade('Method')
                 m.name = name
@@ -247,11 +246,11 @@ class Definitions(WObject):
                 m.binding.output = bindings.get(key)
                 op = ptype.operation(name)
                 p.methods[name] = m
-                
+
     def set_wrapped(self):
         """ set (wrapped|bare) flag on messages """
-        for b in list(self.bindings.values()):
-            for op in list(b.operations.values()):
+        for b in self.bindings.values():
+            for op in b.operations.values():
                 for body in (op.soap.input.body, op.soap.output.body):
                     body.wrapped = False
                     if len(body.parts) != 1:
@@ -267,7 +266,7 @@ class Definitions(WObject):
                         if resolved.builtin():
                             continue
                         body.wrapped = True
-                        
+
     def __getstate__(self):
         nopickle = ('options',)
         state = self.__dict__.copy()
@@ -275,7 +274,7 @@ class Definitions(WObject):
             if k in state:
                 del state[k]
         return state
-    
+
     def __repr__(self):
         return 'Definitions (id=%s)' % self.id
 
@@ -290,7 +289,7 @@ class Import(WObject):
     @ivar imported: The imported object.
     @type imported: L{Definitions}
     """
-    
+
     def __init__(self, root, definitions):
         """
         @param root: An XML root element.
@@ -304,7 +303,7 @@ class Import(WObject):
         self.imported = None
         pmd = self.__metadata__.__print__
         pmd.wrappers['imported'] = repr
-        
+
     def load(self, definitions):
         """ Load the object by opening the URL """
         url = self.location
@@ -320,7 +319,7 @@ class Import(WObject):
             self.import_schema(definitions, d)
             return
         raise Exception('document at "%s" is unknown' % url)
-    
+
     def import_definitions(self, definitions, d):
         """ import/merge wsdl definitions """
         definitions.types += d.types
@@ -329,7 +328,7 @@ class Import(WObject):
         definitions.bindings.update(d.bindings)
         self.imported = d
         log.debug('imported (WSDL):\n%s', d)
-        
+
     def import_schema(self, definitions, d):
         """ import schema as <types/> content """
         if not len(definitions.types):
@@ -339,16 +338,16 @@ class Import(WObject):
             types = definitions.types[-1]
         types.root.append(d.root)
         log.debug('imported (XSD):\n%s', d.root)
-   
+
     def __gt__(self, other):
         return False
-        
+
 
 class Types(WObject):
     """
     Represents <types><schema/></types>.
     """
-    
+
     @classmethod
     def create(cls, definitions):
         root = Element('types', ns=wsdlns)
@@ -364,22 +363,22 @@ class Types(WObject):
         """
         WObject.__init__(self, root, definitions)
         self.definitions = definitions
-        
+
     def contents(self):
         return self.root.getChildren('schema', Namespace.xsdns)
-    
+
     def schema(self):
         return self.definitions.schema
-    
+
     def local(self):
-        return ( self.definitions.schema is None )
-    
+        return self.definitions.schema is None
+
     def imported(self):
-        return ( not self.local() )
-        
+        return not self.local()
+
     def __gt__(self, other):
         return isinstance(other, Import)
-    
+
 
 class Part(NamedObject):
     """
@@ -406,14 +405,14 @@ class Part(NamedObject):
         tns = definitions.tns
         self.element = self.__getref('element', tns)
         self.type = self.__getref('type', tns)
-        
+
     def __getref(self, a, tns):
         """ Get the qualified value of attribute named 'a'."""
         s = self.root.get(a)
         if s is None:
             return s
         else:
-            return qualify(s, self.root, tns)  
+            return qualify(s, self.root, tns)
 
 
 class Message(NamedObject):
@@ -435,11 +434,11 @@ class Message(NamedObject):
         for p in root.getChildren('part'):
             part = Part(p, definitions)
             self.parts.append(part)
-            
+
     def __gt__(self, other):
         return isinstance(other, (Import, Types))
-    
-    
+
+
 class PortType(NamedObject):
     """
     Represents <portType/>.
@@ -478,14 +477,14 @@ class PortType(NamedObject):
                 faults.append(f)
             op.faults = faults
             self.operations[op.name] = op
-            
+
     def resolve(self, definitions):
         """
         Resolve named references to other WSDL objects.
         @param definitions: A definitions object.
         @type definitions: L{Definitions}
         """
-        for op in list(self.operations.values()):
+        for op in self.operations.values():
             if op.input is None:
                 op.input = Message(Element('no-input'), definitions)
             else:
@@ -510,7 +509,7 @@ class PortType(NamedObject):
                 if msg is None:
                     raise Exception("msg '%s', not-found" % f.message)
                 f.message = msg
-                
+
     def operation(self, name):
         """
         Shortcut used to get a contained operation by name.
@@ -522,9 +521,9 @@ class PortType(NamedObject):
         """
         try:
             return self.operations[name]
-        except Exception as e:
+        except Exception:
             raise MethodNotFound(name)
-                
+
     def __gt__(self, other):
         return isinstance(other, (Import, Types, Message))
 
@@ -555,15 +554,15 @@ class Binding(NamedObject):
         self.soap = soap
         self.soap.style = sr.get('style', default='document')
         self.add_operations(self.root, definitions)
-        
+
     def soaproot(self):
         """ get the soap:binding """
         for ns in (soapns, soap12ns):
-            sr =  self.root.getChild('binding', ns=ns)
+            sr = self.root.getChild('binding', ns=ns)
             if sr is not None:
                 return sr
         return None
-        
+
     def add_operations(self, root, definitions):
         """ Add <operation/> children """
         dsop = Element('operation', ns=soapns)
@@ -607,7 +606,7 @@ class Binding(NamedObject):
                 faults.append(f)
             soap.faults = faults
             self.operations[op.name] = op
-            
+
     def body(self, definitions, body, root):
         """ add the input/output body properties """
         if root is None:
@@ -619,7 +618,7 @@ class Binding(NamedObject):
         if parts is None:
             body.parts = ()
         else:
-            body.parts = re.split('[\s,]', parts)
+            body.parts = re.split(r'[\s,]', parts)
         body.use = root.get('use', default='literal')
         ns = root.get('namespace')
         if ns is None:
@@ -627,7 +626,7 @@ class Binding(NamedObject):
         else:
             prefix = root.findPrefix(ns, 'b0')
             body.namespace = (prefix, ns)
-            
+
     def header(self, definitions, parent, root):
         """ add the input/output header properties """
         if root is None:
@@ -647,7 +646,7 @@ class Binding(NamedObject):
         part = root.get('part')
         if part is not None:
             header.part = part
-            
+
     def resolve(self, definitions):
         """
         Resolve named references to other WSDL objects.  This includes
@@ -657,11 +656,11 @@ class Binding(NamedObject):
         @type definitions: L{Definitions}
         """
         self.resolveport(definitions)
-        for op in list(self.operations.values()):
+        for op in self.operations.values():
             self.resolvesoapbody(definitions, op)
             self.resolveheaders(definitions, op)
             self.resolvefaults(definitions, op)
-        
+
     def resolveport(self, definitions):
         """
         Resolve port_type reference.
@@ -674,10 +673,10 @@ class Binding(NamedObject):
             raise Exception("portType '%s', not-found" % self.type)
         else:
             self.type = port_type
-            
+
     def resolvesoapbody(self, definitions, op):
         """
-        Resolve soap body I{message} parts by 
+        Resolve soap body I{message} parts by
         cross-referencing with operation defined in port type.
         @param definitions: A definitions object.
         @type definitions: L{Definitions}
@@ -706,7 +705,7 @@ class Binding(NamedObject):
             soap.output.body.parts = pts
         else:
             soap.output.body.parts = ptop.output.parts
-            
+
     def resolveheaders(self, definitions, op):
         """
         Resolve soap header I{message} references.
@@ -730,7 +729,7 @@ class Binding(NamedObject):
                     break
             if pn == header.part:
                 raise Exception("message '%s' has not part named '%s'" % (ref, pn))
-                        
+
     def resolvefaults(self, definitions, op):
         """
         Resolve soap fault I{message} references by
@@ -752,7 +751,7 @@ class Binding(NamedObject):
             if hasattr(fault, 'parts'):
                 continue
             raise Exception("fault '%s' not defined in portType '%s'" % (fault.name, self.type.name))
-            
+
     def operation(self, name):
         """
         Shortcut used to get a contained operation by name.
@@ -766,9 +765,9 @@ class Binding(NamedObject):
             return self.operations[name]
         except:
             raise MethodNotFound(name)
-            
+
     def __gt__(self, other):
-        return ( not isinstance(other, Service) )
+        return not isinstance(other, Service)
 
 
 class Port(NamedObject):
@@ -781,7 +780,7 @@ class Port(NamedObject):
     @ivar location: The service location (url).
     @type location: str
     """
-    
+
     def __init__(self, root, definitions, service):
         """
         @param root: An XML root element.
@@ -798,9 +797,9 @@ class Port(NamedObject):
         if address is None:
             self.location = None
         else:
-            self.location = address.get('location')
+            self.location = address.get('location').encode('utf-8')
         self.methods = {}
-        
+
     def method(self, name):
         """
         Get a method defined in this portType by name.
@@ -810,7 +809,7 @@ class Port(NamedObject):
         @rtype: I{Method}
         """
         return self.methods.get(name)
-        
+
 
 class Service(NamedObject):
     """
@@ -820,7 +819,7 @@ class Service(NamedObject):
     @ivar methods: The contained methods for all ports.
     @type methods: [Method,..]
     """
-    
+
     def __init__(self, root, definitions):
         """
         @param root: An XML root element.
@@ -833,20 +832,20 @@ class Service(NamedObject):
         for p in root.getChildren('port'):
             port = Port(p, definitions, self)
             self.ports.append(port)
-            
+
     def port(self, name):
         """
         Locate a port by name.
         @param name: A port name.
         @type name: str
         @return: The port object.
-        @rtype: L{Port} 
+        @rtype: L{Port}
         """
         for p in self.ports:
             if p.name == name:
                 return p
         return None
-    
+
     def setlocation(self, url, names=None):
         """
         Override the invocation location (url) for service method.
@@ -856,10 +855,10 @@ class Service(NamedObject):
         @type names: [str,..]
         """
         for p in self.ports:
-            for m in list(p.methods.values()):
+            for m in p.methods.values():
                 if names is None or m.name in names:
-                    m.location = url
-        
+                    m.location = url.encode('utf-8')
+
     def resolve(self, definitions):
         """
         Resolve named references to other WSDL objects.
@@ -879,7 +878,7 @@ class Service(NamedObject):
             p.binding = binding
             filtered.append(p)
         self.ports = filtered
-        
+
     def __gt__(self, other):
         return True
 
@@ -891,16 +890,15 @@ class Factory:
     @type tags: dict
     """
 
-    tags =\
-    {
-        'import' : Import, 
-        'types' : Types, 
-        'message' : Message, 
-        'portType' : PortType,
-        'binding' : Binding,
-        'service' : Service,
+    tags = {
+        'import': Import,
+        'types': Types,
+        'message': Message,
+        'portType': PortType,
+        'binding': Binding,
+        'service': Service,
     }
-    
+
     @classmethod
     def create(cls, root, definitions):
         """
@@ -910,7 +908,7 @@ class Factory:
         @param definitions: A definitions object.
         @type definitions: L{Definitions}
         @return: The created object.
-        @rtype: L{WObject} 
+        @rtype: L{WObject}
         """
         fn = cls.tags.get(root.name)
         if fn is not None:

--- a/suds/xsd/__init__.py
+++ b/suds/xsd/__init__.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -23,7 +23,7 @@ tranparent referenced type resolution and targeted denormalization.
 """
 
 from logging import getLogger
-from suds import *
+from suds.compat import basestring
 from suds.sax import Namespace, splitPrefix
 
 log = getLogger(__name__)
@@ -38,7 +38,8 @@ def qualify(ref, resolvers, defns=Namespace.default):
     @type resolvers: [L{sax.element.Element},]
     @param defns: An optional target namespace used to qualify references
         when no prefix is specified.
-    @type defns: A default namespace I{tuple: (prefix,uri)} used when ref not prefixed.
+    @type defns: A default namespace I{tuple: (prefix,uri)} used when ref not
+        prefixed.
     @return: A qualified reference.
     @rtype: (name, namespace-uri)
     """
@@ -58,6 +59,7 @@ def qualify(ref, resolvers, defns=Namespace.default):
         ns = defns
     return (n, ns[1])
 
+
 def isqref(object):
     """
     Get whether the object is a I{qualified reference}.
@@ -66,21 +68,21 @@ def isqref(object):
     @rtype: boolean
     @see: L{qualify}
     """
-    return (\
-        isinstance(object, tuple) and \
-        len(object) == 2 and \
-        isinstance(object[0], str) and \
-        isinstance(object[1], str))
+    return (
+        isinstance(object, tuple) and
+        len(object) == 2 and
+        isinstance(object[0], basestring) and
+        isinstance(object[1], basestring))
 
 
 class Filter:
     def __init__(self, inclusive=False, *items):
         self.inclusive = inclusive
         self.items = items
+
     def __contains__(self, x):
         if self.inclusive:
-            result = ( x in self.items )
+            result = x in self.items
         else:
-            result = ( x not in self.items )
+            result = x not in self.items
         return result
-

--- a/suds/xsd/deplist.py
+++ b/suds/xsd/deplist.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,7 +19,8 @@ The I{depsolve} module defines a class for performing dependancy solving.
 """
 
 from logging import getLogger
-from suds import *
+
+from suds import Repr
 
 log = getLogger(__name__)
 
@@ -48,7 +49,7 @@ class DepList:
         self.stack = []
         self.pushed = set()
         self.sorted = None
-        
+
     def add(self, *items):
         """
         Add items to be sorted.
@@ -62,7 +63,7 @@ class DepList:
             key = item[0]
             self.index[key] = item
         return self
-        
+
     def sort(self):
         """
         Sort the list based on dependancies.
@@ -73,7 +74,7 @@ class DepList:
         self.pushed = set()
         for item in self.unsorted:
             popped = []
-            self.push(item)            
+            self.push(item)
             while len(self.stack):
                 try:
                     top = self.top()
@@ -90,7 +91,7 @@ class DepList:
                 self.sorted.append(p)
         self.unsorted = self.sorted
         return self.sorted
-    
+
     def top(self):
         """
         Get the item at the top of the stack.
@@ -98,7 +99,7 @@ class DepList:
         @rtype: (item, iter)
         """
         return self.stack[-1]
-    
+
     def push(self, item):
         """
         Push and item onto the sorting stack.
@@ -112,7 +113,7 @@ class DepList:
         frame = (item, iter(item[1]))
         self.stack.append(frame)
         self.pushed.add(item)
-    
+
     def pop(self):
         """
         Pop the top item off the stack and append
@@ -130,11 +131,11 @@ class DepList:
 if __name__ == '__main__':
     a = ('a', ('x',))
     b = ('b', ('a',))
-    c = ('c', ('a','b'))
+    c = ('c', ('a', 'b'))
     d = ('d', ('c',))
-    e = ('e', ('d','a'))
-    f = ('f', ('e','c','d','a'))
+    e = ('e', ('d', 'a'))
+    f = ('f', ('e', 'c', 'd', 'a'))
     x = ('x', ())
     L = DepList()
     L.add(c, e, d, b, f, a, x)
-    print([x[0] for x in L.sort()])
+    print([item[0] for item in L.sort()])

--- a/suds/xsd/doctor.py
+++ b/suds/xsd/doctor.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -20,7 +20,7 @@ schema(s).
 """
 
 from logging import getLogger
-from suds.sax import splitPrefix, Namespace
+from suds.sax import Namespace
 from suds.sax.element import Element
 from suds.plugin import DocumentPlugin, DocumentContext
 
@@ -46,10 +46,10 @@ class Practice(Doctor):
     @ivar doctors: A list of doctors.
     @type doctors: list
     """
-    
+
     def __init__(self):
         self.doctors = []
-        
+
     def add(self, doctor):
         """
         Add a doctor to the practice
@@ -78,7 +78,7 @@ class TnsFilter:
         """
         self.tns = []
         self.add(*tns)
-        
+
     def add(self, *tns):
         """
         Add I{targetNamesapces} to be added.
@@ -97,12 +97,12 @@ class TnsFilter:
         """
         tns = root.get('targetNamespace')
         if len(self.tns):
-            matched = ( tns in self.tns )
+            matched = tns in self.tns
         else:
             matched = 1
-        itself = ( ns == tns )
-        return ( matched and not itself )
-    
+        itself = ns == tns
+        return matched and not itself
+
 
 class Import:
     """
@@ -119,7 +119,7 @@ class Import:
     """
 
     xsdns = Namespace.xsdns
-    
+
     def __init__(self, ns, location=None):
         """
         @param ns: An import namespace.
@@ -130,7 +130,7 @@ class Import:
         self.ns = ns
         self.location = location
         self.filter = TnsFilter()
-        
+
     def setfilter(self, filter):
         """
         Set the filter.
@@ -138,7 +138,7 @@ class Import:
         @type filter: L{TnsFilter}
         """
         self.filter = filter
-        
+
     def apply(self, root):
         """
         Apply the import (rule) to the specified schema.
@@ -157,7 +157,7 @@ class Import:
             node.set('schemaLocation', self.location)
         log.debug('inserting: %s', node)
         root.insert(node)
-        
+
     def add(self, root):
         """
         Add an <xs:import/> to the specified schema root.
@@ -169,8 +169,8 @@ class Import:
         if self.location is not None:
             node.set('schemaLocation', self.location)
         log.debug('%s inserted', node)
-        root.insert(node) 
-        
+        root.insert(node)
+
     def exists(self, root):
         """
         Check to see if the <xs:import/> already exists
@@ -185,7 +185,7 @@ class Import:
             if self.ns == ns:
                 return 1
         return 0
-    
+
 
 class ImportDoctor(Doctor, DocumentPlugin):
     """
@@ -199,7 +199,7 @@ class ImportDoctor(Doctor, DocumentPlugin):
         """
         self.imports = []
         self.add(*imports)
-        
+
     def add(self, *imports):
         """
         Add a namesapce to be checked.
@@ -207,7 +207,7 @@ class ImportDoctor(Doctor, DocumentPlugin):
         @type imports: [L{Import},..]
         """
         self.imports += imports
-        
+
     def examine(self, node):
         for imp in self.imports:
             imp.apply(node)
@@ -223,4 +223,3 @@ class ImportDoctor(Doctor, DocumentPlugin):
         for child in node:
             context.document = child
             self.parsed(context)
-        

--- a/suds/xsd/query.py
+++ b/suds/xsd/query.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,8 +19,7 @@ The I{query} module defines a class for performing schema queries.
 """
 
 from logging import getLogger
-from suds import *
-from suds.sudsobject import *
+from suds import Object, Repr, objid, tostr
 from suds.xsd import qualify, isqref
 from suds.xsd.sxbuiltin import Factory
 
@@ -31,7 +30,7 @@ class Query(Object):
     """
     Schema query base class.
     """
-    
+
     def __init__(self, ref=None):
         """
         @param ref: The schema reference being queried.
@@ -44,7 +43,7 @@ class Query(Object):
         self.resolved = False
         if not isqref(self.ref):
             raise Exception('%s, must be qref' % tostr(self.ref))
-        
+
     def execute(self, schema):
         """
         Execute this query using the specified schema.
@@ -55,7 +54,7 @@ class Query(Object):
         @rtype: L{sxbase.SchemaObject}
         """
         raise Exception('not-implemented by subclass')
-        
+
     def filter(self, result):
         """
         Filter the specified result based on query criteria.
@@ -66,11 +65,11 @@ class Query(Object):
         """
         if result is None:
             return True
-        reject = ( result in self.history )
+        reject = result in self.history
         if reject:
             log.debug('result %s, rejected by\n%s', Repr(result), self)
         return reject
-    
+
     def result(self, result):
         """
         Query result post processing.
@@ -93,7 +92,7 @@ class BlindQuery(Query):
     the specified schema.  It may be used to find Elements and Types but
     will match on an Element first.  This query will also find builtins.
     """
-        
+
     def execute(self, schema):
         if schema.builtin(self.ref):
             name = self.ref[0]
@@ -119,7 +118,7 @@ class TypeQuery(Query):
     Schema query class that searches for Type references in
     the specified schema.  Matches on root types only.
     """
-        
+
     def execute(self, schema):
         if schema.builtin(self.ref):
             name = self.ref[0]
@@ -137,7 +136,7 @@ class GroupQuery(Query):
     Schema query class that searches for Group references in
     the specified schema.
     """
-        
+
     def execute(self, schema):
         result = schema.groups.get(self.ref)
         if self.filter(result):
@@ -147,17 +146,17 @@ class GroupQuery(Query):
 
 class AttrQuery(Query):
     """
-    Schema query class that searches for Attribute references in
-    the specified schema.  Matches on root Attribute by qname first, then searches
-    deep into the document.
+    Schema query class that searches for Attribute references in the specified
+    schema.  Matches on root Attribute by qname first, then searches deep into
+    the document.
     """
-        
+
     def execute(self, schema):
         result = schema.attributes.get(self.ref)
         if self.filter(result):
             result = self.__deepsearch(schema)
         return self.result(result)
-    
+
     def __deepsearch(self, schema):
         from suds.xsd.sxbasic import Attribute
         result = None
@@ -175,7 +174,7 @@ class AttrGroupQuery(Query):
     Schema query class that searches for attributeGroup references in
     the specified schema.
     """
-        
+
     def execute(self, schema):
         result = schema.agrps.get(self.ref)
         if self.filter(result):
@@ -185,17 +184,17 @@ class AttrGroupQuery(Query):
 
 class ElementQuery(Query):
     """
-    Schema query class that searches for Element references in
-    the specified schema.  Matches on root Elements by qname first, then searches
-    deep into the document.
+    Schema query class that searches for Element references in the specified
+    schema.  Matches on root Elements by qname first, then searches deep into
+    the document.
     """
-        
+
     def execute(self, schema):
         result = schema.elements.get(self.ref)
         if self.filter(result):
             result = self.__deepsearch(schema)
         return self.result(result)
-    
+
     def __deepsearch(self, schema):
         from suds.xsd.sxbasic import Element
         result = None

--- a/suds/xsd/sxbase.py
+++ b/suds/xsd/sxbase.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -20,8 +20,9 @@ schema objects.
 """
 
 from logging import getLogger
-from suds import *
-from suds.xsd import *
+from suds import objid, Repr
+from suds.compat import unicode
+from suds.xsd import isqref, Filter, qualify
 from suds.sax.element import Element
 from suds.sax import Namespace
 
@@ -51,7 +52,7 @@ class SchemaObject(object):
     @classmethod
     def prepend(cls, d, s, filter=Filter()):
         """
-        Prepend schema object's from B{s}ource list to 
+        Prepend schema object's from B{s}ource list to
         the B{d}estination list while applying the filter.
         @param d: The destination list.
         @type d: list
@@ -65,11 +66,11 @@ class SchemaObject(object):
             if x in filter:
                 d.insert(i, x)
                 i += 1
-    
+
     @classmethod
     def append(cls, d, s, filter=Filter()):
         """
-        Append schema object's from B{s}ource list to 
+        Append schema object's from B{s}ource list to
         the B{d}estination list while applying the filter.
         @param d: The destination list.
         @type d: list
@@ -103,7 +104,7 @@ class SchemaObject(object):
         self.default = root.get('default')
         self.rawchildren = []
         self.cache = {}
-        
+
     def attributes(self, filter=Filter()):
         """
         Get only the attribute content.
@@ -117,7 +118,7 @@ class SchemaObject(object):
             if child.isattr() and child in filter:
                 result.append((child, ancestry))
         return result
-                
+
     def children(self, filter=Filter()):
         """
         Get only the I{direct} or non-attribute content.
@@ -131,7 +132,7 @@ class SchemaObject(object):
             if not child.isattr() and child in filter:
                 result.append((child, ancestry))
         return result
-                
+
     def get_attribute(self, name):
         """
         Get (find) a I{non-attribute} attribute by name.
@@ -144,7 +145,7 @@ class SchemaObject(object):
             if child.name == name:
                 return (child, ancestry)
         return (None, [])
-                
+
     def get_child(self, name):
         """
         Get (find) a I{non-attribute} child by name.
@@ -170,10 +171,10 @@ class SchemaObject(object):
         if ns[0] is None:
             ns = (prefix, ns[1])
         return ns
-    
+
     def default_namespace(self):
         return self.root.defaultNamespace()
-    
+
     def unbounded(self):
         """
         Get whether this node is unbounded I{(a collection)}
@@ -186,8 +187,8 @@ class SchemaObject(object):
         if max.isdigit():
             return (int(max) > 1)
         else:
-            return ( max == 'unbounded' )
-    
+            return max == 'unbounded'
+
     def optional(self):
         """
         Get whether this type is optional.
@@ -197,17 +198,16 @@ class SchemaObject(object):
         min = self.min
         if min is None:
             min = '1'
-        return ( min == '0' )
-    
+        return min == '0'
+
     def required(self):
         """
         Get whether this type is required.
         @return: True if required, else False
         @rtype: boolean
         """
-        return ( not self.optional() )
-        
-    
+        return not self.optional()
+
     def resolve(self, nobuiltin=False):
         """
         Resolve and return the nodes true self.
@@ -217,7 +217,7 @@ class SchemaObject(object):
         @rtype: L{SchemaObject}
         """
         return self.cache.get(nobuiltin, self)
-    
+
     def sequence(self):
         """
         Get whether this is an <xs:sequence/>
@@ -225,7 +225,7 @@ class SchemaObject(object):
         @rtype: boolean
         """
         return False
-    
+
     def xslist(self):
         """
         Get whether this is an <xs:list/>
@@ -233,7 +233,7 @@ class SchemaObject(object):
         @rtype: boolean
         """
         return False
-    
+
     def all(self):
         """
         Get whether this is an <xs:all/>
@@ -241,7 +241,7 @@ class SchemaObject(object):
         @rtype: boolean
         """
         return False
-    
+
     def choice(self):
         """
         Get whether this is n <xs:choice/>
@@ -249,7 +249,7 @@ class SchemaObject(object):
         @rtype: boolean
         """
         return False
-        
+
     def any(self):
         """
         Get whether this is an <xs:any/>
@@ -257,7 +257,7 @@ class SchemaObject(object):
         @rtype: boolean
         """
         return False
-    
+
     def builtin(self):
         """
         Get whether this is a schema-instance (xs) type.
@@ -265,7 +265,7 @@ class SchemaObject(object):
         @rtype: boolean
         """
         return False
-    
+
     def enum(self):
         """
         Get whether this is a simple-type containing an enumeration.
@@ -273,7 +273,7 @@ class SchemaObject(object):
         @rtype: boolean
         """
         return False
-    
+
     def isattr(self):
         """
         Get whether the object is a schema I{attribute} definition.
@@ -281,7 +281,7 @@ class SchemaObject(object):
         @rtype: boolean
         """
         return False
-    
+
     def extension(self):
         """
         Get whether the object is an extension of another type.
@@ -289,7 +289,7 @@ class SchemaObject(object):
         @rtype: boolean
         """
         return False
-    
+
     def restriction(self):
         """
         Get whether the object is an restriction of another type.
@@ -297,20 +297,20 @@ class SchemaObject(object):
         @rtype: boolean
         """
         return False
-    
+
     def mixed(self):
         """
         Get whether this I{mixed} content.
         """
         return False
-        
+
     def find(self, qref, classes=()):
         """
         Find a referenced type in self or children.
         @param qref: A qualified reference.
         @type qref: qref
         @param classes: A list of classes used to qualify the match.
-        @type classes: [I{class},...] 
+        @type classes: [I{class},...]
         @return: The referenced type.
         @rtype: L{SchemaObject}
         @see: L{qualify()}
@@ -332,7 +332,7 @@ class SchemaObject(object):
         @return: The converted I{language} type.
         """
         return value
-    
+
     def childtags(self):
         """
         Get a list of valid child tag names.
@@ -340,7 +340,7 @@ class SchemaObject(object):
         @rtype: [str,...]
         """
         return ()
-    
+
     def dependencies(self):
         """
         Get a list of dependancies for dereferencing.
@@ -348,7 +348,7 @@ class SchemaObject(object):
         @rtype: (int, [L{SchemaObject},...])
         """
         return (None, [])
-    
+
     def autoqualified(self):
         """
         The list of I{auto} qualified attribute values.
@@ -357,7 +357,7 @@ class SchemaObject(object):
         @rtype: list
         """
         return ['type', 'ref']
-    
+
     def qualify(self):
         """
         Convert attribute values, that are references to other
@@ -378,7 +378,7 @@ class SchemaObject(object):
             qref = qualify(ref, self.root, defns)
             log.debug('%s, convert %s="%s" to %s', self.id, a, ref, qref)
             setattr(self, a, qref)
-            
+
     def merge(self, other):
         """
         Merge another object as needed.
@@ -398,8 +398,7 @@ class SchemaObject(object):
             if v is None:
                 continue
             setattr(self, n, v)
-            
-            
+
     def content(self, collection=None, filter=Filter(), history=None):
         """
         Get a I{flattened} list of this nodes contents.
@@ -424,7 +423,7 @@ class SchemaObject(object):
         for c in self.rawchildren:
             c.content(collection, filter, history[:])
         return collection
-    
+
     def str(self, indent=0, history=None):
         """
         Get a string representation of this object.
@@ -433,13 +432,13 @@ class SchemaObject(object):
         @return: A string.
         @rtype: str
         """
-        if history is None: 
+        if history is None:
             history = []
         if self in history:
             return '%s ...' % Repr(self)
         history.append(self)
-        tab = '%*s'%(indent*3, '')
-        result  = []
+        tab = '%*s' % (indent * 3, '')
+        result = []
         result.append('%s<%s' % (tab, self.id))
         for n in self.description():
             if not hasattr(self, n):
@@ -460,7 +459,7 @@ class SchemaObject(object):
         else:
             result.append(' />')
         return ''.join(result)
-    
+
     def description(self):
         """
         Get the names used for str() and repr() description.
@@ -468,13 +467,13 @@ class SchemaObject(object):
         @rtype: [str,...]
         """
         return ()
-        
+
     def __str__(self):
-        return str(self)
-            
+        return self.__repr__()
+
     def __unicode__(self):
-        return str(self.str())
-    
+         return self.__repr__()
+
     def __repr__(self):
         s = []
         s.append('<%s' % self.id)
@@ -488,15 +487,16 @@ class SchemaObject(object):
         s.append(' />')
         myrep = ''.join(s)
         return myrep
-    
+
     def __len__(self):
         n = 0
-        for x in self: n += 1
+        for x in self:
+            n += 1
         return n
-    
+
     def __iter__(self):
         return Iter(self)
-    
+
     def __getitem__(self, index):
         i = 0
         for c in self:
@@ -506,16 +506,16 @@ class SchemaObject(object):
 
 class Iter:
     """
-    The content iterator - used to iterate the L{Content} children.  The iterator
-    provides a I{view} of the children that is free of container elements
-    such as <sequence/> and <choice/>.
+    The content iterator - used to iterate the L{Content} children.  The
+    iterator provides a I{view} of the children that is free of container
+    elements such as <sequence/> and <choice/>.
     @ivar stack: A stack used to control nesting.
     @type stack: list
     """
-    
+
     class Frame:
         """ A content iterator frame. """
-        
+
         def __init__(self, sx):
             """
             @param sx: A schema object.
@@ -524,8 +524,8 @@ class Iter:
             self.sx = sx
             self.items = sx.rawchildren
             self.index = 0
-            
-        def __next__(self):
+
+        def next(self):
             """
             Get the I{next} item in the frame's collection.
             @return: The next item or None
@@ -535,7 +535,7 @@ class Iter:
                 result = self.items[self.index]
                 self.index += 1
                 return result
-    
+
     def __init__(self, sx):
         """
         @param sx: A schema object.
@@ -543,7 +543,7 @@ class Iter:
         """
         self.stack = []
         self.push(sx)
-        
+
     def push(self, sx):
         """
         Create a frame and push the specified object.
@@ -551,7 +551,7 @@ class Iter:
         @type sx: L{SchemaObject}
         """
         self.stack.append(Iter.Frame(sx))
-        
+
     def pop(self):
         """
         Pop the I{top} frame.
@@ -563,7 +563,7 @@ class Iter:
             return self.stack.pop()
         else:
             raise StopIteration()
-        
+
     def top(self):
         """
         Get the I{top} frame.
@@ -575,8 +575,11 @@ class Iter:
             return self.stack[-1]
         else:
             raise StopIteration()
-    
+
     def __next__(self):
+        return self.next()
+
+    def next(self):
         """
         Get the next item.
         @return: A tuple: the next (child, ancestry).
@@ -585,16 +588,16 @@ class Iter:
         """
         frame = self.top()
         while True:
-            result = next(frame)
+            result = frame.next()
             if result is None:
                 self.pop()
-                return next(self)
+                return self.next()
             if isinstance(result, Content):
                 ancestry = [f.sx for f in self.stack]
                 return (result, ancestry)
             self.push(result)
-            return next(self)
-    
+            return self.next()
+
     def __iter__(self):
         return self
 
@@ -603,7 +606,7 @@ class XBuiltin(SchemaObject):
     """
     Represents an (xsd) schema <xs:*/> node
     """
-    
+
     def __init__(self, schema, name):
         """
         @param schema: The containing schema.
@@ -613,13 +616,13 @@ class XBuiltin(SchemaObject):
         SchemaObject.__init__(self, schema, root)
         self.name = name
         self.nillable = True
-            
+
     def namespace(self, prefix=None):
         return Namespace.xsdns
-    
+
     def builtin(self):
         return True
-    
+
     def resolve(self, nobuiltin=False):
         return self
 
@@ -631,7 +634,7 @@ class Content(SchemaObject):
     """
     pass
 
-    
+
 class NodeFinder:
     """
     Find nodes based on flexable criteria.  The I{matcher} is
@@ -650,7 +653,7 @@ class NodeFinder:
         """
         self.matcher = matcher
         self.limit = limit
-        
+
     def find(self, node, list):
         """
         Traverse the tree looking for matches.

--- a/suds/xsd/sxbasic.py
+++ b/suds/xsd/sxbasic.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -19,7 +19,6 @@ The I{sxbasic} module provides classes that represent
 I{basic} schema objects.
 """
 
-from logging import getLogger
 from suds import *
 from suds.xsd import *
 from suds.xsd.sxbase import *
@@ -39,7 +38,7 @@ class RestrictionMatcher:
     """
     def match(self, n):
         return isinstance(n, Restriction)
-    
+
 
 class TypedContent(Content):
     """
@@ -70,7 +69,7 @@ class TypedContent(Content):
         else:
             result = resolved.resolve(nobuiltin)
         return result
-    
+
     def qref(self):
         """
         Get the I{type} qualified reference to the referenced xsd type.
@@ -97,28 +96,28 @@ class Complex(SchemaObject):
     @cvar childtags: A list of valid child node names
     @type childtags: (I{str},...)
     """
-        
+
     def childtags(self):
         return (
-            'attribute', 
-            'attributeGroup', 
-            'sequence', 
-            'all', 
-            'choice', 
+            'attribute',
+            'attributeGroup',
+            'sequence',
+            'all',
+            'choice',
             'complexContent',
-            'simpleContent', 
-            'any', 
+            'simpleContent',
+            'any',
             'group')
 
     def description(self):
         return ('name',)
-    
+
     def extension(self):
         for c in self.rawchildren:
             if c.extension():
                 return True
         return False
-    
+
     def mixed(self):
         for c in self.rawchildren:
             if isinstance(c, SimpleContent) and c.mixed():
@@ -132,14 +131,14 @@ class Group(SchemaObject):
     @cvar childtags: A list of valid child node names
     @type childtags: (I{str},...)
     """
-        
+
     def childtags(self):
         return ('sequence', 'all', 'choice')
-        
+
     def dependencies(self):
         deps = []
         midx = None
-        if self.ref is not None:     
+        if self.ref is not None:
             query = GroupQuery(self.ref)
             g = query.execute(self.schema)
             if g is None:
@@ -148,14 +147,14 @@ class Group(SchemaObject):
             deps.append(g)
             midx = 0
         return (midx, deps)
-    
+
     def merge(self, other):
         SchemaObject.merge(self, other)
         self.rawchildren = other.rawchildren
 
     def description(self):
         return ('name', 'ref',)
-    
+
 
 class AttributeGroup(SchemaObject):
     """
@@ -163,7 +162,7 @@ class AttributeGroup(SchemaObject):
     @cvar childtags: A list of valid child node names
     @type childtags: (I{str},...)
     """
-        
+
     def childtags(self):
         return ('attribute', 'attributeGroup')
 
@@ -179,14 +178,14 @@ class AttributeGroup(SchemaObject):
             deps.append(ag)
             midx = 0
         return (midx, deps)
-    
+
     def merge(self, other):
         SchemaObject.merge(self, other)
         self.rawchildren = other.rawchildren
 
     def description(self):
         return ('name', 'ref',)
-    
+
 
 class Simple(SchemaObject):
     """
@@ -195,31 +194,31 @@ class Simple(SchemaObject):
 
     def childtags(self):
         return ('restriction', 'any', 'list',)
-    
+
     def enum(self):
         for child, ancestry in self.children():
             if isinstance(child, Enumeration):
                 return True
         return False
-    
+
     def mixed(self):
         return len(self)
 
     def description(self):
         return ('name',)
-    
+
     def extension(self):
         for c in self.rawchildren:
             if c.extension():
                 return True
         return False
-    
+
     def restriction(self):
         for c in self.rawchildren:
             if c.restriction():
                 return True
         return False
-    
+
 
 class List(SchemaObject):
     """
@@ -231,23 +230,23 @@ class List(SchemaObject):
 
     def description(self):
         return ('name',)
-    
+
     def xslist(self):
         return True
 
-   
+
 class Restriction(SchemaObject):
     """
     Represents an (xsd) schema <xs:restriction/> node
     """
-    
+
     def __init__(self, schema, root):
         SchemaObject.__init__(self, schema, root)
         self.ref = root.get('base')
 
     def childtags(self):
         return ('enumeration', 'attribute', 'attributeGroup')
-    
+
     def dependencies(self):
         deps = []
         midx = None
@@ -261,7 +260,7 @@ class Restriction(SchemaObject):
                 deps.append(super)
                 midx = 0
         return (midx, deps)
-    
+
     def restriction(self):
         return True
 
@@ -269,11 +268,11 @@ class Restriction(SchemaObject):
         SchemaObject.merge(self, other)
         filter = Filter(False, self.rawchildren)
         self.prepend(self.rawchildren, other.rawchildren, filter)
-        
+
     def description(self):
         return ('ref',)
-    
-    
+
+
 class Collection(SchemaObject):
     """
     Represents an (xsd) schema collection node:
@@ -301,6 +300,7 @@ class All(Collection):
     def all(self):
         return True
 
+
 class Choice(Collection):
     """
     Represents an (xsd) schema <xs:choice/> node.
@@ -313,16 +313,16 @@ class ComplexContent(SchemaObject):
     """
     Represents an (xsd) schema <xs:complexContent/> node.
     """
-        
+
     def childtags(self):
         return ('attribute', 'attributeGroup', 'extension', 'restriction')
-    
+
     def extension(self):
         for c in self.rawchildren:
             if c.extension():
                 return True
         return False
-    
+
     def restriction(self):
         for c in self.rawchildren:
             if c.restriction():
@@ -334,22 +334,22 @@ class SimpleContent(SchemaObject):
     """
     Represents an (xsd) schema <xs:simpleContent/> node.
     """
-        
+
     def childtags(self):
         return ('extension', 'restriction')
-    
+
     def extension(self):
         for c in self.rawchildren:
             if c.extension():
                 return True
         return False
-    
+
     def restriction(self):
         for c in self.rawchildren:
             if c.restriction():
                 return True
         return False
-    
+
     def mixed(self):
         return len(self)
 
@@ -362,26 +362,26 @@ class Enumeration(Content):
     def __init__(self, schema, root):
         Content.__init__(self, schema, root)
         self.name = root.get('value')
-        
+
     def enum(self):
         return True
 
-    
+
 class Element(TypedContent):
     """
     Represents an (xsd) schema <xs:element/> node.
     """
-    
+
     def __init__(self, schema, root):
         TypedContent.__init__(self, schema, root)
         a = root.get('form')
         if a is not None:
-            self.form_qualified = ( a == 'qualified' )
+            self.form_qualified = a == 'qualified'
         a = self.root.get('nillable')
         if a is not None:
-            self.nillable = ( a in ('1', 'true') )
+            self.nillable = a in ('1', 'true')
         self.implany()
-            
+
     def implany(self):
         """
         Set the type as any when implicit.
@@ -390,27 +390,25 @@ class Element(TypedContent):
         @return: self
         @rtype: L{Element}
         """
-        if self.type is None and \
-            self.ref is None and \
-            self.root.isempty():
-                self.type = self.anytype()
+        if self.type is None and self.ref is None and self.root.isempty():
+            self.type = self.anytype()
         return self
-        
+
     def childtags(self):
         return ('attribute', 'simpleType', 'complexType', 'any',)
-    
+
     def extension(self):
         for c in self.rawchildren:
             if c.extension():
                 return True
         return False
-    
+
     def restriction(self):
         for c in self.rawchildren:
             if c.restriction():
                 return True
         return False
-    
+
     def dependencies(self):
         deps = []
         midx = None
@@ -423,17 +421,17 @@ class Element(TypedContent):
             deps.append(e)
             midx = 0
         return (midx, deps)
-    
+
     def merge(self, other):
         SchemaObject.merge(self, other)
         self.rawchildren = other.rawchildren
 
     def description(self):
         return ('name', 'ref', 'type')
-        
+
     def anytype(self):
         """ create an xsd:anyType reference """
-        p,u = Namespace.xsdns
+        p, u = Namespace.xsdns
         mp = self.root.findPrefix(u)
         if mp is None:
             mp = p
@@ -445,19 +443,19 @@ class Extension(SchemaObject):
     """
     Represents an (xsd) schema <xs:extension/> node.
     """
-    
+
     def __init__(self, schema, root):
         SchemaObject.__init__(self, schema, root)
         self.ref = root.get('base')
-        
+
     def childtags(self):
         return ('attribute',
-                'attributeGroup', 
-                'sequence', 
-                'all', 
-                'choice', 
+                'attributeGroup',
+                'sequence',
+                'all',
+                'choice',
                 'group')
-        
+
     def dependencies(self):
         deps = []
         midx = None
@@ -476,13 +474,13 @@ class Extension(SchemaObject):
         SchemaObject.merge(self, other)
         filter = Filter(False, self.rawchildren)
         self.prepend(self.rawchildren, other.rawchildren, filter)
-        
+
     def extension(self):
-        return ( self.ref is not None )
+        return self.ref is not None
 
     def description(self):
         return ('ref',)
-    
+
 
 class Import(SchemaObject):
     """
@@ -496,13 +494,13 @@ class Import(SchemaObject):
     @ivar opened: Opened and I{imported} flag.
     @type opened: boolean
     """
-    
+
     locations = {}
-    
+
     @classmethod
     def bind(cls, ns, location=None):
         """
-        Bind a namespace to a schema location (URI).  
+        Bind a namespace to a schema location (URI).
         This is used for imports that don't specify a schemaLocation.
         @param ns: A namespace-uri.
         @type ns: str
@@ -513,7 +511,7 @@ class Import(SchemaObject):
         if location is None:
             location = ns
         cls.locations[ns] = location
-    
+
     def __init__(self, schema, root):
         SchemaObject.__init__(self, schema, root)
         self.ns = (None, root.get('namespace'))
@@ -521,7 +519,7 @@ class Import(SchemaObject):
         if self.location is None:
             self.location = self.locations.get(self.ns[1])
         self.opened = False
-        
+
     def open(self, options):
         """
         Open and import the refrenced schema.
@@ -533,7 +531,11 @@ class Import(SchemaObject):
         if self.opened:
             return
         self.opened = True
-        log.debug('%s, importing ns="%s", location="%s"', self.id, self.ns[1], self.location)
+        log.debug('%s, importing ns="%s", location="%s"',
+                  self.id,
+                  self.ns[1],
+                  self.location
+                  )
         result = self.locate()
         if result is None:
             if self.location is None:
@@ -542,7 +544,7 @@ class Import(SchemaObject):
                 result = self.download(options)
         log.debug('imported:\n%s', result)
         return result
-    
+
     def locate(self):
         """ find the schema locally """
         if self.ns[1] == self.schema.tns[1]:
@@ -565,10 +567,10 @@ class Import(SchemaObject):
             msg = 'imported schema (%s) at (%s), failed' % (self.ns[1], url)
             log.error('%s, %s', self.id, msg, exc_info=True)
             raise Exception(msg)
- 
+
     def description(self):
         return ('ns', 'location')
-    
+
 
 class Include(SchemaObject):
     """
@@ -578,16 +580,16 @@ class Include(SchemaObject):
     @ivar opened: Opened and I{imported} flag.
     @type opened: boolean
     """
-    
+
     locations = {}
-    
+
     def __init__(self, schema, root):
         SchemaObject.__init__(self, schema, root)
         self.location = root.get('schemaLocation')
         if self.location is None:
             self.location = self.locations.get(self.ns[1])
         self.opened = False
-        
+
     def open(self, options):
         """
         Open and include the refrenced schema.
@@ -620,7 +622,7 @@ class Include(SchemaObject):
             msg = 'include schema at (%s), failed' % url
             log.error('%s, %s', self.id, msg, exc_info=True)
             raise Exception(msg)
-        
+
     def __applytns(self, root):
         """ make sure included schema has same tns. """
         TNS = 'targetNamespace'
@@ -631,12 +633,11 @@ class Include(SchemaObject):
         else:
             if self.schema.tns[1] != tns:
                 raise Exception('%s mismatch' % TNS)
-                
- 
+
     def description(self):
         return ('location')
 
-   
+
 class Attribute(TypedContent):
     """
     Represents an (xsd) <attribute/> node
@@ -645,10 +646,10 @@ class Attribute(TypedContent):
     def __init__(self, schema, root):
         TypedContent.__init__(self, schema, root)
         self.use = root.get('use', default='')
-        
+
     def childtags(self):
         return ('restriction',)
-        
+
     def isattr(self):
         return True
 
@@ -659,9 +660,9 @@ class Attribute(TypedContent):
         @rtype: str
         """
         return self.root.get('default', default='')
-    
+
     def optional(self):
-        return ( self.use != 'required' )
+        return self.use != 'required'
 
     def dependencies(self):
         deps = []
@@ -675,7 +676,7 @@ class Attribute(TypedContent):
             deps.append(a)
             midx = 0
         return (midx, deps)
-    
+
     def description(self):
         return ('name', 'ref', 'type')
 
@@ -690,45 +691,44 @@ class Any(Content):
         root.set('note', 'synthesized (any) child')
         child = Any(self.schema, root)
         return (child, [])
-    
+
     def get_attribute(self, name):
         root = self.root.clone()
         root.set('note', 'synthesized (any) attribute')
         attribute = Any(self.schema, root)
         return (attribute, [])
-    
+
     def any(self):
         return True
-    
-    
+
+
 class Factory:
     """
     @cvar tags: A factory to create object objects based on tag.
     @type tags: {tag:fn,}
     """
 
-    tags =\
-    {
-        'import' : Import,
-        'include' : Include, 
-        'complexType' : Complex,
-        'group' : Group,
-        'attributeGroup' : AttributeGroup, 
-        'simpleType' : Simple,
-        'list' : List,
-        'element' : Element,
-        'attribute' : Attribute,
-        'sequence' : Sequence,
-        'all' : All,
-        'choice' : Choice,
-        'complexContent' : ComplexContent,
-        'simpleContent' : SimpleContent,
-        'restriction' : Restriction,
-        'enumeration' : Enumeration,
-        'extension' : Extension,
-        'any' : Any,
+    tags = {
+        'import': Import,
+        'include': Include,
+        'complexType': Complex,
+        'group': Group,
+        'attributeGroup': AttributeGroup,
+        'simpleType': Simple,
+        'list': List,
+        'element': Element,
+        'attribute': Attribute,
+        'sequence': Sequence,
+        'all': All,
+        'choice': Choice,
+        'complexContent': ComplexContent,
+        'simpleContent': SimpleContent,
+        'restriction': Restriction,
+        'enumeration': Enumeration,
+        'extension': Extension,
+        'any': Any,
     }
-    
+
     @classmethod
     def maptag(cls, tag, fn):
         """
@@ -739,7 +739,7 @@ class Factory:
         @type fn: fn|class.
         """
         cls.tags[tag] = fn
-    
+
     @classmethod
     def create(cls, root, schema):
         """
@@ -749,7 +749,7 @@ class Factory:
         @param schema: A schema object.
         @type schema: L{schema.Schema}
         @return: The created object.
-        @rtype: L{SchemaObject} 
+        @rtype: L{SchemaObject}
         """
         fn = cls.tags.get(root.name)
         if fn is not None:
@@ -778,7 +778,7 @@ class Factory:
                 c = cls.build(node, schema, child.childtags())
                 child.rawchildren = c
         return children
-    
+
     @classmethod
     def collate(cls, children):
         imports = []
@@ -807,8 +807,6 @@ class Factory:
         for i in imports:
             children.remove(i)
         return (children, imports, attributes, elements, types, groups, agrps)
-
-    
 
 
 #######################################################

--- a/suds/xsd/sxbuiltin.py
+++ b/suds/xsd/sxbuiltin.py
@@ -1,6 +1,6 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 3 of the 
+# published by the Free Software Foundation; either version 3 of the
 # License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -20,36 +20,35 @@ XSD I{builtin} schema objects.
 """
 
 from logging import getLogger
-from suds import *
-from suds.xsd import *
-from suds.sax.date import *
+from suds.compat import basestring
 from suds.xsd.sxbase import XBuiltin
-import datetime as dt
+import suds.sax.date  as dt
+import datetime
 
 
 log = getLogger(__name__)
-    
-    
+
+
 class XString(XBuiltin):
     """
     Represents an (xsd) <xs:string/> node
     """
     pass
 
-  
+
 class XAny(XBuiltin):
     """
     Represents an (xsd) <any/> node
     """
-    
+
     def __init__(self, schema, name):
         XBuiltin.__init__(self, schema, name)
         self.nillable = False
-    
+
     def get_child(self, name):
         child = XAny(self.schema, name)
         return (child, [])
-    
+
     def any(self):
         return True
 
@@ -58,50 +57,43 @@ class XBoolean(XBuiltin):
     """
     Represents an (xsd) boolean builtin type.
     """
-    
+
     translation = (
-        { '1':True,'true':True,'0':False,'false':False },
-        { True:'true',1:'true',False:'false',0:'false' },
+        {
+            '1': True,
+            'true': True,
+            '0': False,
+            'false': False
+        },
+        {
+            True: 'true',
+            1: 'true',
+            False: 'false',
+            0: 'false'
+        },
     )
-        
+
     def translate(self, value, topython=True):
         if topython:
-            if isinstance(value, str):
+            if isinstance(value, basestring):
                 return XBoolean.translation[0].get(value)
             else:
                 return None
         else:
-            if isinstance(value, (bool,int)):
+            if isinstance(value, (bool, int)):
                 return XBoolean.translation[1].get(value)
             else:
                 return value
 
-   
+
 class XInteger(XBuiltin):
     """
     Represents an (xsd) xs:int builtin type.
     """
-        
+
     def translate(self, value, topython=True):
         if topython:
-            if isinstance(value, str) and len(value):
-                return int(value)
-            else:
-                return None
-        else:
-            if isinstance(value, int):
-                return str(value)
-            else:
-                return value
-            
-class XLong(XBuiltin):
-    """
-    Represents an (xsd) xs:long builtin type.
-    """
-        
-    def translate(self, value, topython=True):
-        if topython:
-            if isinstance(value, str) and len(value):
+            if isinstance(value, basestring) and len(value):
                 return int(value)
             else:
                 return None
@@ -111,15 +103,33 @@ class XLong(XBuiltin):
             else:
                 return value
 
-       
+
+class XLong(XBuiltin):
+    """
+    Represents an (xsd) xs:long builtin type.
+    """
+
+    def translate(self, value, topython=True):
+        if topython:
+            if isinstance(value, basestring) and len(value):
+                return int(value)
+            else:
+                return None
+        else:
+            if isinstance(value, int):
+                return str(value)
+            else:
+                return value
+
+
 class XFloat(XBuiltin):
     """
     Represents an (xsd) xs:float builtin type.
     """
-        
+
     def translate(self, value, topython=True):
         if topython:
-            if isinstance(value, str) and len(value):
+            if isinstance(value, basestring) and len(value):
                 return float(value)
             else:
                 return None
@@ -128,22 +138,22 @@ class XFloat(XBuiltin):
                 return str(value)
             else:
                 return value
-            
+
 
 class XDate(XBuiltin):
     """
     Represents an (xsd) xs:date builtin type.
     """
-        
+
     def translate(self, value, topython=True):
         if topython:
-            if isinstance(value, str) and len(value):
-                return Date(value).date
+            if isinstance(value, basestring) and len(value):
+                return dt.Date(value).value
             else:
                 return None
         else:
-            if isinstance(value, dt.date):
-                return str(Date(value))
+            if isinstance(value, datetime.date):
+                return str(dt.Date(value))
             else:
                 return value
 
@@ -152,16 +162,16 @@ class XTime(XBuiltin):
     """
     Represents an (xsd) xs:time builtin type.
     """
-        
+
     def translate(self, value, topython=True):
         if topython:
-            if isinstance(value, str) and len(value):
-                return Time(value).time
+            if isinstance(value, basestring) and len(value):
+                return dt.Time(value).value
             else:
                 return None
         else:
-            if isinstance(value, dt.date):
-                return str(Time(value))
+            if isinstance(value, datetime.time):
+                return str(dt.Time(value))
             else:
                 return value
 
@@ -171,80 +181,79 @@ class XDateTime(XBuiltin):
     Represents an (xsd) xs:datetime builtin type.
     """
 
-    def translate(self, value, topython=True):
+    def translate(self, value, topython=True):	    
         if topython:
-            if isinstance(value, str) and len(value):
-                return DateTime(value).datetime
+            if isinstance(value, basestring) and len(value):
+                return dt.DateTime(value).value
             else:
                 return None
         else:
-            if isinstance(value, dt.date):
-                return str(DateTime(value))
+            if isinstance(value, datetime.datetime):
+                return str(dt.DateTime(value))
             else:
                 return value
-            
-            
+
+
 class Factory:
 
-    tags =\
-    {
+    tags = {
         # any
-        'anyType' : XAny,
+        'anyType': XAny,
         # strings
-        'string' : XString,
-        'normalizedString' : XString,
-        'ID' : XString,
-        'Name' : XString,
-        'QName' : XString,
-        'NCName' : XString,
-        'anySimpleType' : XString,
-        'anyURI' : XString,
-        'NOTATION' : XString,
-        'token' : XString,
-        'language' : XString,
-        'IDREFS' : XString,
-        'ENTITIES' : XString,
-        'IDREF' : XString,
-        'ENTITY' : XString,
-        'NMTOKEN' : XString,
-        'NMTOKENS' : XString,
+        'string': XString,
+        'normalizedString': XString,
+        'ID': XString,
+        'Name': XString,
+        'QName': XString,
+        'NCName': XString,
+        'anySimpleType': XString,
+        'anyURI': XString,
+        'NOTATION': XString,
+        'token': XString,
+        'language': XString,
+        'IDREFS': XString,
+        'ENTITIES': XString,
+        'IDREF': XString,
+        'ENTITY': XString,
+        'NMTOKEN': XString,
+        'NMTOKENS': XString,
         # binary
-        'hexBinary' : XString,
-        'base64Binary' : XString,
+        'hexBinary': XString,
+        'base64Binary': XString,
         # integers
-        'int' : XInteger,
-        'integer' : XInteger,
-        'unsignedInt' : XInteger,
-        'positiveInteger' : XInteger,
-        'negativeInteger' : XInteger,
-        'nonPositiveInteger' : XInteger,
-        'nonNegativeInteger' : XInteger,
+        'int': XInteger,
+        'integer': XInteger,
+        'unsignedInt': XInteger,
+        'positiveInteger': XInteger,
+        'negativeInteger': XInteger,
+        'nonPositiveInteger': XInteger,
+        'nonNegativeInteger': XInteger,
         # longs
-        'long' : XLong,
-        'unsignedLong' : XLong,
+        'long': XLong,
+        'unsignedLong': XLong,
         # shorts
-        'short' : XInteger,
-        'unsignedShort' : XInteger,
-        'byte' : XInteger,
-        'unsignedByte' : XInteger,
+        'short': XInteger,
+        'unsignedShort': XInteger,
+        'byte': XInteger,
+        'unsignedByte': XInteger,
         # floats
-        'float' : XFloat,
-        'double' : XFloat,
-        'decimal' : XFloat,
+        'float': XFloat,
+        'double': XFloat,
+        'decimal': XFloat,
         # dates & times
-        'date' : XDate,
-        'time' : XTime,
+        'date': XDate,
+        'time': XTime,
         'dateTime': XDateTime,
         'duration': XString,
-        'gYearMonth' : XString,
-        'gYear' : XString,
-        'gMonthDay' : XString,
-        'gDay' : XString,
-        'gMonth' : XString,
+        'gYearMonth': XString,
+        'gYear': XString,
+        'gMonthDay': XString,
+        'gDay': XString,
+        'gMonth': XString,
         # boolean
-        'boolean' : XBoolean,
+        'boolean': XBoolean,
     }
-    
+
     @classmethod
     def maptag(cls, tag, fn):
         """
@@ -265,7 +274,7 @@ class Factory:
         @param name: The name.
         @type name: str
         @return: The created object.
-        @rtype: L{XBuiltin} 
+        @rtype: L{XBuiltin}
         """
         fn = cls.tags.get(name)
         if fn is not None:


### PR DESCRIPTION
This replaces the embedded `suds` library with its python3-compatible version - `suds-py3`
The previous version was converted to python3 using `2to3` and didn't work correctly. As a result, `sphere-engine` calls were failing. 
