### PR TITLE
Removed ideone API key from repo

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,5 +1,3 @@
-IDEONE_USERNAME = "ronreiter"
-IDEONE_PASSWORD = "18132ce2b97e"
 CACHE_HOST = "direct.learnpython.org"
 DB_HOST = "direct.learnpython.org"
 SECRET_KEY = "this is a secret. really."

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from flask import Flask, render_template, request, make_response, session, Respo
 from ideone import Ideone
 
 import constants
+import secrets
 
 
 courses = json.load(open("courses.json"))
@@ -65,8 +66,8 @@ tutorial_data = {}
 
 def run_code(code, language_id):
     ideone_api = Ideone(
-        constants.IDEONE_USERNAME,
-        constants.IDEONE_PASSWORD,
+        secrets.IDEONE_USERNAME,
+        secrets.IDEONE_PASSWORD,
         api_url='http://ronreiter.compilers.sphere-engine.com/api/1/service.wsdl')
 
     code = ideone_api.create_submission(code, language_id=language_id, std_input="")["link"]

--- a/secrets.py
+++ b/secrets.py
@@ -1,0 +1,3 @@
+# The values below must be replaced with real usernames, passwords, etc.
+IDEONE_USERNAME = "some_username"
+IDEONE_PASSWORD = "some_password"


### PR DESCRIPTION
This removes `IDEONE_USERNAME` and `IDEONE_PASSWORD` from `constants.py` and moves them to a separate file `secrets.py` which stores placeholders instead of actual secrets.

Resolves #554.