### PR TITLE
CPP: Fix Variables & Types Tutorial Bug

### DIFF
--- a/tutorials/learn-cpp.org/en/Variables and Types.md
+++ b/tutorials/learn-cpp.org/en/Variables and Types.md
@@ -82,7 +82,7 @@ Tutorial Code
 
       /* Your code goes here */
 
-      cout << "The sum of a, b, and c is" << sum << endl;
+      cout << "The sum of a, b, and c is " << sum << endl;
       return 0;
     }
 


### PR DESCRIPTION
Expected solution defines there should be a space between the "is" and the sum value.

Fixes the tutorial starting code to add in this space