### PR TITLE
Fixing struct definition

### DIFF
--- a/tutorials/learn-cpp.org/en/Structures.md
+++ b/tutorials/learn-cpp.org/en/Structures.md
@@ -12,10 +12,10 @@ A structure is basically a user-defined datatype which consists of other datatyp
     //This is how you'll usually define a structure    
     using namespace std;
     struct MyOwnStructure { // keyword "struct" followed by a name, followed by braces containing the datatypes you like, followed by a semicolon
-        int poperty_one,
-        int property_two,
-        char property_three,
-        bool property_four
+        int poperty_one;
+        int property_two;
+        char property_three;
+        bool property_four;
         //...
     };
 


### PR DESCRIPTION
The tutorial code defines the fields of a struct with `int property_one,` which is incorrect and may confuse beginners. Replacing the commas with semicolons makes the code work.