### PR TITLE
fix display bug related to usage of double bracket [[

### DIFF
--- a/tutorials/learnshell.org/de/Decision Making.md
+++ b/tutorials/learnshell.org/de/Decision Making.md
@@ -64,7 +64,7 @@ Der Ausdruck kann eine logische Kombination von Vergleichen sein. Die Negation w
 
 ### Logische Kombinationen
 
-    if [[ $VAR_A -eq 1 && ($VAR_B = "bee" || $VAR_T = "tee") ]] ; then
+    if [[ $VAR_A[0] -eq 1 && ($VAR_B = "bee" || $VAR_T = "tee") ]] ; then
         Befehl...
     fi
 

--- a/tutorials/learnshell.org/en/Decision Making.md
+++ b/tutorials/learnshell.org/en/Decision Making.md
@@ -64,7 +64,7 @@ The expression can be a logical combination of comparisons: negation is denoted 
 
 ### Logical combinations
 
-    if [[ $VAR_A -eq 1 && ($VAR_B = "bee" || $VAR_T = "tee") ]] ; then
+    if [[ $VAR_A[0] -eq 1 && ($VAR_B = "bee" || $VAR_T = "tee") ]] ; then
         command...
     fi
 

--- a/tutorials/learnshell.org/tr/Koşullu Durumlar.md
+++ b/tutorials/learnshell.org/tr/Koşullu Durumlar.md
@@ -67,7 +67,7 @@ Mantıksal işleyiciler, aynen matematikte kullanıldığı gibi programlama dil
 
 ### Mantıksal işleyicileri kullanma
 
-    if [[ $deg_A -eq 1 && ($deg_B = "bee" || $deg_T = "tee") ]] ; then
+    if [[ $deg_A[0] -eq 1 && ($deg_B = "bee" || $deg_T = "tee") ]] ; then
         # işlenecek kod bloğu
     fi
 


### PR DESCRIPTION
There is a tiny bug on https://www.learnshell.org/en/Decision_Making Logical Combinations chapter. Spotted by @MaatheN

This => `if [[ $VAR_A[0] -eq 1 && ($VAR_B = "bee" || $VAR_T = "tee") ]] ; then` is displayed like this => `if <a href='/en/_%24VAR_A_-eq_1_%26%26_%28%24VAR_B_%3D_%22bee%22_'>| $VAR_T = "tee") </a> ; then`

This is due to wikify function which use double brackets to detect wiki links. To solve the underlying issue, it would be necessary to change the way wiki links are detected but this tiny fix just avoid the issue by modifying the code example. This code example  is still relevant to the rest of the tutorial.