### PR TITLE
Error in Learn-C Linked List Solution

### DIFF
--- a/tutorials/learn-c.org/en/Linked lists.md
+++ b/tutorials/learn-c.org/en/Linked lists.md
@@ -350,7 +350,8 @@ Solution
             return pop(head);
         }
 
-        previous = current = (*head)->next;
+        previous = *head;
+        current = (*head)->next;
         while (current) {
             if (current->val == val) {
                 previous->next = current->next;


### PR DESCRIPTION
Assigning previous and current to (*head)->next before the while loop will cause and error if the value being searched for is after the head of the list.  In this case 2. Since previous and current point the to same location before the while loop. It will hit the if statement before reassigning previous.  So previous->next already equals current->next.  This causes an error since freeing current would be freeing where previous is pointing.

Fixed this by assigning previous to current on line 353 and moving the current assignment of (*head)->next down to line 354.