### PR TITLE
Fix segfault in learn-c.org/xx/Linked lists.md

### DIFF
--- a/tutorials/learn-c.org/de/Linked lists.md
+++ b/tutorials/learn-c.org/de/Linked lists.md
@@ -210,6 +210,10 @@ There are a few edge cases we need to take care of, so make sure you understand 
             current = current->next;
         }
 
+        if (current->next == NULL) {
+            return -1;
+        }
+
         temp_node = current->next;
         retval = temp_node->val;
         current->next = temp_node->next;

--- a/tutorials/learn-c.org/en/Linked lists.md
+++ b/tutorials/learn-c.org/en/Linked lists.md
@@ -223,6 +223,10 @@ There are a few edge cases we need to take care of, so make sure you understand 
             current = current->next;
         }
 
+        if (current->next == NULL) {
+            return -1;
+        }
+
         temp_node = current->next;
         retval = temp_node->val;
         current->next = temp_node->next;

--- a/tutorials/learn-c.org/nl/Linked lists.md
+++ b/tutorials/learn-c.org/nl/Linked lists.md
@@ -223,6 +223,10 @@ There are a few edge cases we need to take care of, so make sure you understand 
             current = current->next;
         }
 
+        if (current->next == NULL) {
+            return -1;
+        }
+
         temp_node = current->next;
         retval = temp_node->val;
         current->next = temp_node->next;


### PR DESCRIPTION
Account for edge case in `remove_by_index` when index = size of the array.

Error example:
```c
int main() {
	node_t * head = malloc(sizeof(node_t));
	if (head == NULL)
		return 1;

	head->next = NULL;
	head->val = 5;

	int ret = remove_by_index(&head, 1);

	printf("Returned: %d\n", ret);
	printf("Head pointer: %p\n", head);
}
```
