### PR TITLE
🎯Updated the documentation of Function Context.

### DIFF
--- a/tutorials/learn-js.org/en/Function Context.md
+++ b/tutorials/learn-js.org/en/Function Context.md
@@ -33,7 +33,7 @@ For example, let's call `printName` with `person` as the context using the `call
 
 ### call/apply vs bind
 
-The difference between `call`/`apply` and `bind` is that `bind` returns a new function identical to the old function, except that the value of `this` in the new function is now the object it was bound to.  `call`/`apply` calls the function with `this` being the bound object, but it does not return a return a new function or change the original, it calls it with a different value for `this`.
+The difference between `call`/`apply` and `bind` is that `bind` returns a new function identical to the old function, except that the value of `this` in the new function is now the object it was bound to.  `call`/`apply` calls the function with `this` being the bound object, but it does not return a new function or change the original, it calls it with a different value for `this`.
 
 For example:
 


### PR DESCRIPTION
✌️There was a repetition of a certain phrase in the documentation of Function Context - call/apply vs bind. The phrase - 
        "return a" was repeated twice. Fixed the typo.

🌱You can find the fixation in the screenshot provided-

![contribution](https://user-images.githubusercontent.com/71728035/148590134-aff04030-7d30-48d9-a637-d47f5317f3f1.jpg)
.