### PR TITLE
Removing ambiguity in final exercises

### DIFF
--- a/tutorials/learnpython.org/en/Functions.md
+++ b/tutorials/learnpython.org/en/Functions.md
@@ -81,11 +81,11 @@ Tutorial Code
 
 # Modify this function to return a list of strings as defined above
 def list_benefits():
-    pass
+    return []
 
 # Modify this function to concatenate to each benefit - " is a benefit of functions!"
 def build_sentence(benefit):
-    pass
+    return ""
 
 def name_the_benefits_of_functions():
     list_of_benefits = list_benefits()

--- a/tutorials/learnpython.org/en/Loops.md
+++ b/tutorials/learnpython.org/en/Loops.md
@@ -99,6 +99,7 @@ numbers = [
 ]
 
 # your code goes here
+for number in numbers:
 
 Expected Output
 ---------------

--- a/tutorials/learnpython.org/en/Modules and Packages.md
+++ b/tutorials/learnpython.org/en/Modules and Packages.md
@@ -246,6 +246,7 @@ Tutorial Code
 import re
 
 # Your code goes here
+find_members = []
 
 Expected Output
 ---------------


### PR DESCRIPTION
These three commits remove ambiguity for students due to the fact that the pass/fail requirement of the last exercise needs a specific variable name that is not shown to the student until they attempt to run their code. Adding these variable names directly into the exercises lessens the chances of a false negative.

Also removing the pass keyword as it was never explained.