### PR TITLE
Add "Run & Edit Full Tutorial" button on python Functions and Lists pages

### DIFF
--- a/tutorials/learnpython.org/en/Functions.md
+++ b/tutorials/learnpython.org/en/Functions.md
@@ -94,6 +94,13 @@ def name_the_benefits_of_functions():
 
 name_the_benefits_of_functions()
 
+<div style="padding: 20px 0;">
+    <a href="https://app.datacamp.com/workspace/new?_tag=template&templateKey=learnpython-functions&utm_source=learnpython.org&utm_medium=docs&utm_term=functions&utm_content=run_code_in_workspace"
+                    style="font-size: 16px; padding: 12px 16px; border-radius: 4px; background: rgba(3, 239, 98); color: #1f2937; font-weight: 600; text-decoration: none;"
+                    target="_blank">
+    Run & Edit Full Tutorial
+    </a>
+</div>
 
 Expected Output
 ---------------

--- a/tutorials/learnpython.org/en/Functions.md
+++ b/tutorials/learnpython.org/en/Functions.md
@@ -76,24 +76,6 @@ In this exercise you'll use an existing function, and while adding your own to c
 
 3. Run and see all the functions work together!
 
-Tutorial Code
--------------
-
-# Modify this function to return a list of strings as defined above
-def list_benefits():
-    return []
-
-# Modify this function to concatenate to each benefit - " is a benefit of functions!"
-def build_sentence(benefit):
-    return ""
-
-def name_the_benefits_of_functions():
-    list_of_benefits = list_benefits()
-    for benefit in list_of_benefits:
-        print(build_sentence(benefit))
-
-name_the_benefits_of_functions()
-
 <div style="padding: 20px 0;">
     <a href="https://app.datacamp.com/workspace/new?_tag=template&templateKey=learnpython-functions&utm_source=learnpython.org&utm_medium=docs&utm_term=functions&utm_content=run_code_in_workspace"
                     style="font-size: 16px; padding: 12px 16px; border-radius: 4px; background: rgba(3, 239, 98); color: #1f2937; font-weight: 600; text-decoration: none;"
@@ -101,6 +83,25 @@ name_the_benefits_of_functions()
     Run & Edit Full Tutorial
     </a>
 </div>
+
+Tutorial Code
+-------------
+
+    # Modify this function to return a list of strings as defined above
+    def list_benefits():
+        return []
+
+    # Modify this function to concatenate to each benefit - " is a benefit of functions!"
+    def build_sentence(benefit):
+        return ""
+
+    def name_the_benefits_of_functions():
+        list_of_benefits = list_benefits()
+        for benefit in list_of_benefits:
+            print(build_sentence(benefit))
+
+    name_the_benefits_of_functions()
+
 
 Expected Output
 ---------------

--- a/tutorials/learnpython.org/en/Lists.md
+++ b/tutorials/learnpython.org/en/Lists.md
@@ -27,21 +27,6 @@ In this exercise, you will need to add numbers and strings to the correct lists 
 
 You will also have to fill in the variable second_name with the second name in the names list, using the brackets operator `[]`. Note that the index is zero-based, so if you want to access the second item in the list, its index will be 1.
 
-Tutorial Code
--------------
-numbers = []
-strings = []
-names = ["John", "Eric", "Jessica"]
-
-# write your code here
-second_name = None
-
-
-# this code should write out the filled arrays and the second name in the names list (Eric).
-print(numbers)
-print(strings)
-print("The second name on the names list is %s" % second_name)
-
 <div style="padding: 20px 0;">
     <a href="https://app.datacamp.com/workspace/new?_tag=template&templateKey=learnpython-lists&utm_source=learnpython.org&utm_medium=docs&utm_term=lists&utm_content=run_code_in_workspace"
                     style="font-size: 16px; padding: 12px 16px; border-radius: 4px; background: rgba(3, 239, 98); color: #1f2937; font-weight: 600; text-decoration: none;"
@@ -49,6 +34,22 @@ print("The second name on the names list is %s" % second_name)
     Run & Edit Full Tutorial
     </a>
 </div>
+
+Tutorial Code
+-------------
+    numbers = []
+    strings = []
+    names = ["John", "Eric", "Jessica"]
+
+    # write your code here
+    second_name = None
+
+
+    # this code should write out the filled arrays and the second name in the names list (Eric).
+    print(numbers)
+    print(strings)
+    print("The second name on the names list is %s" % second_name)
+
 
 Expected Output
 ---------------

--- a/tutorials/learnpython.org/en/Lists.md
+++ b/tutorials/learnpython.org/en/Lists.md
@@ -42,6 +42,14 @@ print(numbers)
 print(strings)
 print("The second name on the names list is %s" % second_name)
 
+<div style="padding: 20px 0;">
+    <a href="https://app.datacamp.com/workspace/new?_tag=template&templateKey=learnpython-lists&utm_source=learnpython.org&utm_medium=docs&utm_term=lists&utm_content=run_code_in_workspace"
+                    style="font-size: 16px; padding: 12px 16px; border-radius: 4px; background: rgba(3, 239, 98); color: #1f2937; font-weight: 600; text-decoration: none;"
+                    target="_blank">
+    Run & Edit Full Tutorial
+    </a>
+</div>
+
 Expected Output
 ---------------
 


### PR DESCRIPTION
## Changes
- Add "Run & Edit Full Tutorial" button on python Functions and Lists pages that opens up a DataCamp workspace with the code from that page.
- Only these 2 pages will be affected: python Functions and Lists

## Screenshots
<img width="1163" alt="image" src="https://user-images.githubusercontent.com/38893718/156155230-ea3e3670-a070-4020-88b3-766db892f552.png">
<img width="992" alt="image" src="https://user-images.githubusercontent.com/38893718/156155297-034d33e3-2d8a-43ef-aab2-9a9600941e6a.png">
