### PR TITLE
Missing parentheses in call to 'print'

### DIFF
--- a/tutorials/learnpython.org/it/Variabili e tipi.md
+++ b/tutorials/learnpython.org/it/Variabili e tipi.md
@@ -64,11 +64,11 @@ myint = None
 
 # verifica del codice
 if mystring == "ciao":
-    print "Stringa: %s" % mystring
+    print ("Stringa: %s" % mystring)
 if isinstance(myfloat, float) and myfloat == 10.0:
-    print "Numero in virgola mobile: %d" % myfloat
+    print ("Numero in virgola mobile: %d" % myfloat)
 if isinstance(myint, int) and myint == 20:
-    print "Intero: %d" % myint
+    print ("Intero: %d" % myint)
 
 Expected Output
 ---------------
@@ -78,3 +78,6 @@ Intero: 20
 
 Solution
 --------
+mystring = "ciao"
+myfloat = 10.0
+myint = 20


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/python3.5/py_compile.py", line 125, in compile
    _optimize=optimize)
  File "<frozen importlib._bootstrap_external>", line 735, in source_to_code
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "./prog.py", line 8
    print "Stringa: %s" % mystring
                      ^
SyntaxError: Missing parentheses in call to 'print'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.5/py_compile.py", line 129, in compile
    raise py_exc
py_compile.PyCompileError:   File "./prog.py", line 8
    print "Stringa: %s" % mystring
                      ^
SyntaxError: Missing parentheses in call to 'print'