### PR TITLE
Fix Java Generic Types tutorial formatting and update Exceptions link to JRE8

### DIFF
--- a/tutorials/learnjavaonline.org/en/Exceptions.md
+++ b/tutorials/learnjavaonline.org/en/Exceptions.md
@@ -1,22 +1,22 @@
 Tutorial
 --------
 Exceptions are thrown every time an error occurs. The list of all built in exceptions can be accessed at
-http://docs.oracle.com/javase/7/docs/api/java/lang/Exception.html.
+http://docs.oracle.com/javase/8/docs/api/java/lang/Exception.html.
 
 Exceptions are handled using try/catch statements. All code that may throw an exception must follow the Catch
 or Specify requirement. To follow that requirement, just wrap the code that may throw an error in a try block. If,
 for some reason, it's not suitable or you cannot use try/catch, you must specify all exceptions a method/function
 can throw using the `throws` keyword
 
-	public void writeFile() throws IOException 
+	public void writeFile() throws IOException
 
 You can also throw an exception in the code using throw new:
 
 	throw new IllegalArgumentException("Number not above 0");
-	/* Will print 
+	/* Will print
 		Exception in thread "Main": java.lang.IllegalArgumentException: Number not above 0
 	*/
-	
+
 Exceptions are handled using try/catch, which are covered in an earlier lesson:
 
 	try {

--- a/tutorials/learnjavaonline.org/en/Generic Types.md
+++ b/tutorials/learnjavaonline.org/en/Generic Types.md
@@ -1,38 +1,39 @@
 Tutorial
 --------
 
-Java Generic methods and generic classes enable programmers to specify, with a single method declaration, a set of related methods, or with a single class declaration, a set of related types, respectively.Generic in java is similar to templates in C++. It allows the user to parameterized the types in classes, or interface. The user have to <> to specify parameter types in generic class creation. 
+Java Generic methods and generic classes enable programmers to specify, with a single method declaration, a set of related methods, or with a single class declaration, a set of related types, respectively.Generic in java is similar to templates in C++. It allows the user to parameterized the types in classes, or interface. The user have to <> to specify parameter types in generic class creation.
 
 
 ## Generic Methods
-public <T> methodName()
-{
-    ...
-}
+
+    public <T> methodName()
+    {
+        ...
+    }
 
 ## Generic class
-public class ClassName<T>
-{
-    ...
-}
+
+    public class ClassName<T>
+    {
+        ...
+    }
 
 ## Generic variable
-T varibaleName;
+    T variableName;
 
 Lets see a code sample to easily understand the generic types.
 
-//This a Generic class declaration
+    //This a Generic class declaration
     class Generic<T> // This class accepts any data type
     {
-
-// Generic variable declaration
-        T variable; 
+        // Generic variable declaration
+        T variable;
         public Generic(T variable) // constructor  for generic class
         {
             this.variable = variable;
         }
 
-//generic method declaration
+        //generic method declaration
         public <T> getVariable() // method to get the variable of generic type
         {
             return variable;
@@ -45,20 +46,21 @@ This the main class where the object for generic class is created here.
     {
         public static void main(String args[])
         {
+        // Here the object is created for Generic class of type Integer.
+        Generic<Integer> intvar = new Generic<Integer>(20);
+        System.out.println(intvar.getVariable());
 
-// Here the object is created for the generic class
-            Generic<Integer> intvar = new Generic<Integer>(20); // Here the object is created for Generic class of type Integer.
-            System.out.println(intvar.getVariable());
-           
-            Generic<String> strvar = new Generic<String>("I love Java"); // Here the object is created for Generic class of type String.
-            System.out.println(strvar.getVariable());
-
+        // Here the object is created for Generic class of type String.
+        Generic<String> strvar = new Generic<String>("I love Java");
+        System.out.println(strvar.getVariable());
         }
 
     }
 
 ## OUTPUT
-20                                                                                                                                                                                 
+
+20
+
 I love Java
 
 The code shows you that the class constructor while object creation can accept any data type.
@@ -66,57 +68,55 @@ The code shows you that the class constructor while object creation can accept a
 Exercise
 --------
 
-Create a Generic class which accepts String and Integer datatype at a time. Create a object for the same. Pass in 30 and "I love Generic types" has parameters. print the both in next next line   
+Create a Generic class which accepts String and Integer datatype at a time. Create a object for the same. Pass in 30 and "I love Generic types" as parameters. Print  both in the next line.
 
 Tutorial Code
 -------------
 // Create a generic class here.
 
-public class Main {
-
-    public static void main(String[] args) {
-
-        // Your code goes here
-
+    public class Main {
+        public static void main(String[] args) {
+            // Your code goes here
+        }
     }
-
-}
 
 Expected Output
 ---------------
+
 30
+
 I love Generic types
 
 
 Solution
 --------
 
-class Generic<I, S> 
-{
-    I variable1;  
-    S variable2;
-    public Generic(I variable1, S variable2) 
+    class Generic<Integer, String>
     {
-        this.variable1 = variable1;
-        this.variable2 = variable2;
+        Integer variable1;
+        String variable2;
+        public Generic(Integer variable1, String variable2)
+        {
+            this.variable1 = variable1;
+            this.variable2 = variable2;
+        }
+        public Integer getVariable1()
+        {
+            return variable1;
+        }
+        public String getVariable2()
+        {
+            return variable2;
+        }
     }
-    public I getVariable1() 
+    class Main
     {
-        return variable1;
-    }
-    public S getVariable2() 
-    {
-        return variable2;
-    }
-}
-class Main
-{
-    public static void main(String args[])
-    {
-        Generic<Integer, String> intstrvar = new Generic<Integer, String>(30,"I love Generic types");
-        System.out.println(intstrvar.getVariable1());
-        System.out.println(intstrvar.getVariable2());
+        public static void main(String args[])
+        {
+            Generic<Integer, String> intstrvar = new Generic<Integer, String>(30,"I love Generic types");
+            System.out.println(intstrvar.getVariable1());
+            System.out.println(intstrvar.getVariable2());
+
+        }
 
     }
-
-}


### PR DESCRIPTION
While working through the tutorials, I noticed that the formatting of the Java Generic Types tutorial was broken because the indentation was wrong in the source. I fixed that and also corrected some wording other minor inconsistencies.

Also, the Exceptions tutorial was still linking to JRE7 as a reference. I think that is too outdated.