### PR TITLE
Update Map, Filter, Reduce.md: remove extra argument

### DIFF
--- a/tutorials/learnpython.org/en/Map, Filter, Reduce.md
+++ b/tutorials/learnpython.org/en/Map, Filter, Reduce.md
@@ -217,7 +217,7 @@ my_numbers = [4, 6, 9, 23, 5]
 
 # Fix all three respectively.
 map_result = list(map(lambda x: x, my_floats))
-filter_result = list(filter(lambda name: name, my_names, my_names))
+filter_result = list(filter(lambda name: name, my_names))
 reduce_result = reduce(lambda num1, num2: num1 * num2, my_numbers, 0)
 
 print(map_result)


### PR DESCRIPTION
There is an extra argument to `filter`, in the exercise.

I think it is a mistake, unless it was intentional in order for the user to fix it?