### PR TITLE
Fixing Car Model

### DIFF
--- a/tutorials/learn-ts.org/en/Interfaces.md
+++ b/tutorials/learn-ts.org/en/Interfaces.md
@@ -32,7 +32,7 @@ Tutorial Code
     // write the interface here
 
     let myCar: Car = {
-        model: "Toyota",
+        model: "Tesla",
         year: 2022
     };
 
@@ -40,7 +40,7 @@ Tutorial Code
 
 Expected Output
 -------------------
-  Tesla
+Tesla
 
 Solution
 -----------


### PR DESCRIPTION
The original object had `Toyota` written in its `model` property by default, but the expected output was `Tesla` and the user had no clue he had to change that value. Also, two unnecessary spaces were removed from the "expected output" zone.