### PR TITLE
Add Tutorial for Python F-Strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Contributors
 - qwong95
 - AddaxSoft
 - derco0n
+- Kjentleman
 - ...<perhaps you>...
 
 <p>This project is supported by:</p>

--- a/static/js/datacamp.js
+++ b/static/js/datacamp.js
@@ -1,5 +1,5 @@
 $(function() {
-  var template = "<div data-datacamp-exercise data-lang=\"python\" data-height=\"{{height}}\" data-impact-tracking-link=\"\/c\/67577\/1012793\/13294\"><code data-type=\"sample-code\">{{code}}</div></div>",
+  var template = "<div data-datacamp-exercise data-lang=\"python\" data-lang-version=\"3.6\" data-height=\"{{height}}\" data-impact-tracking-link=\"\/c\/67577\/1012793\/13294\"><code data-type=\"sample-code\">{{code}}</div></div>",
       LINEHEIGHT = 14,
       EXTRA = 100;
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -202,7 +202,7 @@
 <script src="/static/js/bootbox.min.js"></script>
 
 {% if domain_data.language == "python" and domain_data.language_code == 'en'  %}
-<script type="text/javascript" src="//cdn.datacamp.com/dcl-react.js.gz"></script>
+<script type="text/javascript" src="//cdn.datacamp.com/dcl/latest/dcl-react.js.gz"></script>
 <script src="/static/js/datacamp.js"></script>
 {% endif %}
 

--- a/templates/index-python.html
+++ b/templates/index-python.html
@@ -47,7 +47,7 @@
 
             <!-- DataCamp-Light exercise -->
             {% if page_title %}
-            <div data-datacamp-exercise data-lang="python" data-height="400" data-impact-tracking-link="/c/67577/1012793/13294">
+            <div data-datacamp-exercise data-lang="python" data-lang-version="3.6" data-height="400" data-impact-tracking-link="/c/67577/1012793/13294">
               <code data-type="pre-exercise-code"></code>
               <code data-type="sample-code">{{tutorial_data.code}}</code>
               <code data-type="solution">{{tutorial_data.solution}}</code>

--- a/tutorials/learnpython.org/en/Literal String Interpolation.md
+++ b/tutorials/learnpython.org/en/Literal String Interpolation.md
@@ -35,28 +35,29 @@ Exercise
 --------
 
 Rewrite the code using f-strings to produce the following output:
-    `Hello John Doe. Your new balance is $63.54.`
+    `Hello John Doe. You have 14 fruit.`
 
 Tutorial Code
 -------------
 
 first_name = "John"
 last_name = "Doe"
-balance = 53.44
-deposit = 10.10
+apples = 10
+pears = 4
 
-print("Hello %s %s. Your current balance is $%f" & (first_name, last_name, balance))
+# Rewrite this print statement using f-strings
+print("Hello %s %s. You have %d apples." % (first_name, last_name, apples))
 
 Expected Output
 ---------------
-test_output_contains("Hello John Doe. Your new balance is $63.54.", no_output_msg= "Remember to add the `f` before the string and compute the new balance by adding the deposit")
+test_output_contains("Hello John Doe. You have 14 fruit.", no_output_msg= "Remember to add the `f` before the string and compute the total number of fruit.")
 success_msg('Great work!')
 
 Solution
 --------
 first_name = "John"
 last_name = "Doe"
-balance = 53.44
-deposit = 10.10
+apples = 10
+pears = 4
 
-print(f"Hello {first_name} {last_name}. Your new balance is ${balance + deposit}")
+print(f"Hello {first_name} {last_name}. You have {apples + pears} fruit.")

--- a/tutorials/learnpython.org/en/Literal String Interpolation.md
+++ b/tutorials/learnpython.org/en/Literal String Interpolation.md
@@ -1,0 +1,62 @@
+Tutorial
+--------
+
+In Python 3.6 another way of formatting strings was introdcued called Literal String Interpolation or more commonly known as f-strings due to the f character that proceeds the string.
+
+String interpolation is the process of replacing the placeholders in the string literal with their corresponding values. This is the same as the C-style formatting from the previous tutorial where the placeholders of %s, %d, etc. are replaced with the values provided after the string literal.
+
+    # This prints out "John is 23 years old."
+    name = "John"
+    age = 23
+
+    print("%s is %d years old." % (name, age))
+
+%s is a placeholder for name and %d is a placeholder for age. When the string is interpolated the values of name and age replace the %s and %d symbols.
+
+F-strings makes string interpolation easier by placing the desired interpolated value in-line with the string inside of curly brackets {}. So instead of `"Hello, %s" % name`, we simply use `f"Hello, {name}"`
+
+    # This also prints out "John is 23 years old."
+    name = "John"
+    age = 23
+
+    print(f"{name} is {age} years old.")
+
+You may also have noticed this eliminates the need to specify the value's type, as f-strings handle this for you.
+
+A poweful benefit of F-strings is that they allow you execute expressions or arthmetic inside the curly brackets.
+
+    # This prints out "2 * 6 = 12"
+    a = 2
+    b = 6
+    
+    print(f"{a} * {b} = {a * b}")
+
+Exercise
+--------
+
+Rewrite the code using f-strings to produce the following output:
+    `Hello John Doe. Your new balance is $63.54.`
+
+Tutorial Code
+-------------
+
+first_name = "John"
+last_name = "Doe"
+balance = 53.44
+deposit = 10.10
+
+print("Hello %s %s. Your current balance is $%f" & (first_name, last_name, balance))
+
+Expected Output
+---------------
+test_output_contains("Hello John Doe. Your new balance is $63.54.", no_output_msg= "Remember to add the `f` before the string and compute the new balance by adding the deposit")
+success_msg('Great work!')
+
+Solution
+--------
+first_name = "John"
+last_name = "Doe"
+balance = 53.44
+deposit = 10.10
+
+print(f"Hello {first_name} {last_name}. Your new balance is ${balance + deposit}")

--- a/tutorials/learnpython.org/en/Welcome.md
+++ b/tutorials/learnpython.org/en/Welcome.md
@@ -22,6 +22,7 @@ Just click on the chapter you wish to begin from, and follow the instructions. G
 - [[Lists]]
 - [[Basic Operators]]
 - [[String Formatting]]
+- [[Literal String Interpolation]]
 - [[Basic String Operations]]
 - [[Conditions]]
 - [[Loops]]


### PR DESCRIPTION
- Use latest version of `datacamp-light` ([v3](https://github.com/datacamp/datacamp-light/tree/v3))
- Set Python version to `3.6` using new `data-lang-version` attribute
- Add Python tutorial for Literal String Interpolation aka f-strings
- Adds self as contributor

_Please note, this change dependent on the stability of datacamp-light v3. It is likely best to wait until it has been merged into a stable release._