### PR TITLE
Update PHP Strings Exercise to Include Array Rejoining Task

### DIFF
--- a/tutorials/learn-php.org/en/Strings.md
+++ b/tutorials/learn-php.org/en/Strings.md
@@ -49,18 +49,23 @@ To join back an array to a single string separated with commas, we use the `impl
 Exercise
 --------
 
-Split string that contains the list of numbers into a new array called number_list.
+Split string that contains the list of numbers into a new array called number_list and then rejoin the number_list array into a single string separated with colons(:) .
 
 Tutorial Code
 -------------
 
-<?php
+<?php 
 $numbers = "38,42,58,48,33,59,87,17,20,8,98,14,62,66,14,62,97,66,74,78,66,2,79,29,72,6,3,71,46,68,48,4,12,52,66,48,14,39,63,69,81,61,21,77,10,44,39,82,19,77,100,98,53,95,30,17,30,96,68,47,81,52,82,11,13,83,10,14,49,96,27,73,42,76,71,15,81,36,77,38,17,2,29,100,26,86,22,18,38,64,82,51,39,7,88,53,82,30,98,86";
 
 // TODO: split the $numbers variable to an array
 // called $number_list
 
 print_r($number_list);
+
+// TODO: rejoin the number_list array into a colon separated single string 
+// called $numbers_colon
+
+print_r($numbers_colon)
 ?>
 
 Expected Output
@@ -169,6 +174,7 @@ Array
     [98] => 98
     [99] => 86
 )
+38:42:58:48:33:59:87:17:20:8:98:14:62:66:14:62:97:66:74:78:66:2:79:29:72:6:3:71:46:68:48:4:12:52:66:48:14:39:63:69:81:61:21:77:10:44:39:82:19:77:100:98:53:95:30:17:30:96:68:47:81:52:82:11:13:83:10:14:49:96:27:73:42:76:71:15:81:36:77:38:17:2:29:100:26:86:22:18:38:64:82:51:39:7:88:53:82:30:98:86
 
 Solution
 --------
@@ -179,4 +185,8 @@ $numbers = "38,42,58,48,33,59,87,17,20,8,98,14,62,66,14,62,97,66,74,78,66,2,79,2
 $number_list = explode(",", $numbers);
 
 print_r($number_list);
+
+$numbers_colon = implode(":", $number_list);
+
+print_r($numbers_colon);
 ?>


### PR DESCRIPTION
Modified the existing Strings exercise in tutorials/learn-php.org/en/Strings.md to include a new task. The updated exercise now requires users to rejoin the resulting array into a string with numbers separated by a colon (':'). This change aims to provide additional practice with PHP string manipulation and array handling functions.

Changes made:

    Added instructions to rejoin the array into a string with elements separated by a colon.
    Updated the example code to reflect the new task.

This enhancement provides a more comprehensive exercise for learners, reinforcing key concepts of explode and implode in PHP.