### PR TITLE
Fix incorrect array destructuring syntax in lesson

### DIFF
--- a/tutorials/learn-js.org/en/Destructuring.md
+++ b/tutorials/learn-js.org/en/Destructuring.md
@@ -47,10 +47,7 @@ With arrays:
     let three = numbers[1];
 
     // ES6 Destructuring
-    let [two, three] = numbers;
-
-    // We can give them other names too
-    let [two: positionZero, three: positionOne] = numbers;
+    let [positionZero,positionOne] = numbers;
 
     console.log(positionZero)       // prints '2'
     console.log(positionOne)        // prints '3'


### PR DESCRIPTION
# Fix Incorrect Syntax in Array Destructuring Lesson

## Issue
The array destructuring lesson on [learn-js.org](https://www.learn-js.org/) contains incorrect syntax for renaming variables during array destructuring. It uses object destructuring syntax (e.g., `let [two: positionZero, three: positionOne] = numbers;`), which is invalid in array destructuring.

### Problem Code
```javascript
let numbers = ['2', '3', '7'];
let [two: positionZero, three: positionOne] = numbers;

console.log(positionZero); // This results in an error

