### PR TITLE
Fixed C++ pointers exercise assignment and reformatted for readability 

### DIFF
--- a/tutorials/learn-cpp.org/en/Pointers.md
+++ b/tutorials/learn-cpp.org/en/Pointers.md
@@ -79,11 +79,12 @@ C++ also introduced 2 new concepts on pointers:
 Exercise
 --------
 Indirectly access and modify the value of "n":
-- Create 2 pointers p1 and p2 for the given integer "n", 
-- with p1 being the void pointer, 
-- and p2 the int pointer.
-- p2 must be assigned to p1.
-- indirectly increase the value of n's content by 1 and print the value.
+
+- Create 2 pointers p1 and p2 for the given integer "n".
+- p1 is the void pointer.
+- p2 the int pointer.
+- p1 must be assigned to p2.
+- Indirectly increase the value of n's content by 1 and print the value.
 
 Tutorial Code
 -------------


### PR DESCRIPTION
I noticed that the part within the exercise where it says "p2 must be assigned to p1" was wrong, contrary to the solution provided and also to the assignment in question, so I changed that part to "p1 must be assigned to p2".
I also noticed that there could have been a problem with formatting the exercise so I made an attempt at fixing the formatting, hopefully.