### PR TITLE
typo: remove trailing pipes from random lines in Special Variables le…

### DIFF
--- a/tutorials/learnshell.org/en/Special Variables.md
+++ b/tutorials/learnshell.org/en/Special Variables.md
@@ -4,14 +4,14 @@ Tutorial
 In last tutorial about shell function, you use "$1" represent the first argument passed to function_A. Moreover, here are some special variables in shell:
 
 
-* `$0` - The filename of the current script.|
-* `$n` - The Nth argument passed to script was invoked or function was called.|
-* `$#` - The number of argument passed to script or function.|
-* `$@` - All arguments passed to script or function.|
-* `$*` - All arguments passed to script or function.|
-* `$?` - The exit status of the last command executed.|
-* `$$` - The process ID of the current shell. For shell scripts, this is the process ID under which they are executing.|
-* `$!` - The process number of the last background command.|
+* `$0` - The filename of the current script.
+* `$n` - The Nth argument passed to script was invoked or function was called.
+* `$#` - The number of argument passed to script or function.
+* `$@` - All arguments passed to script or function.
+* `$*` - All arguments passed to script or function.
+* `$?` - The exit status of the last command executed.
+* `$$` - The process ID of the current shell. For shell scripts, this is the process ID under which they are executing.
+* `$!` - The process number of the last background command.
     
 
 ### Example:

--- a/tutorials/learnshell.org/tr/Special Variables.md
+++ b/tutorials/learnshell.org/tr/Special Variables.md
@@ -4,14 +4,14 @@ Tutorial
 In last tutorial about shell function, you use "$1" represent the first argument passed to function_A. Moreover, here are some special variables in shell:
 
 
-* `$0` - The filename of the current script.|
-* `$n` - The Nth argument passed to script was invoked or function was called.|
-* `$#` - The number of argument passed to script or function.|
-* `$@` - All arguments passed to script or function.|
-* `$*` - All arguments passed to script or function.|
-* `$?` - The exit status of the last command executed.|
-* `$$` - The process ID of the current shell. For shell scripts, this is the process ID under which they are executing.|
-* `$!` - The process number of the last background command.|
+* `$0` - The filename of the current script.
+* `$n` - The Nth argument passed to script was invoked or function was called.
+* `$#` - The number of argument passed to script or function.
+* `$@` - All arguments passed to script or function.
+* `$*` - All arguments passed to script or function.
+* `$?` - The exit status of the last command executed.
+* `$$` - The process ID of the current shell. For shell scripts, this is the process ID under which they are executing.
+* `$!` - The process number of the last background command.
     
 
 ### Example:


### PR DESCRIPTION
Remove weird pipe symbols in the end of some lines in Special Variables lesson of Shell tutorial. I assume somebody tried to make a table and gave up half-way through, but forgot to clean up.