### PR TITLE
fix(learnpython): correct malformed print statement in Input and Output solution

### DIFF
--- a/tutorials/learnpython.org/en/Input and Output.md
+++ b/tutorials/learnpython.org/en/Input and Output.md
@@ -90,4 +90,4 @@ Solution
     country = input("Enter your country: ")
     
     # Displaying the formatted sentence with name, age, and country
-    print("Hello, my name is {}, I am {} years old, and I am from {}.".format(name, age, country)) name is {}, I am {} years old, and I am from {}.".format(name, age, country))
+    print("Hello, my name is {}, I am {} years old, and I am from {}.".format(name, age, country))


### PR DESCRIPTION
This PR fixes a syntax error in the "Input and Output" exercise solution.

The previous solution block contained a malformed print statement,
which caused the exercise to fail with a syntax error when submitted.

This update replaces the broken line with a valid print statement:

```python
print("Hello, my name is {}, I am {} years old, and I am from {}.".format(name, age, country))
```

Verification steps:
- Ran the LearnPython.org environment locally to confirm the syntax error no longer appears.
- Tested the corrected solution code directly using redirected stdin to simulate user input.
- Confirmed the script executes successfully and produces the expected formatted output.

This resolves the issue reported in #863.
