### PR TITLE
chore: remove obsolete `version` attribute from docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   app:
     build: ./


### PR DESCRIPTION
Remove the `version` attribute, which has been obsolete since Compose v2, in 2020 and throws a warning each time you start the containers.

From the official docker documentation ([source](https://docs.docker.com/compose/intro/history/)):
> Compose v2, announced in 2020, is written in Go and is invoked with docker compose. Unlike v1, Compose v2 ignores the version top-level element in the compose.yaml file and relies entirely on the Compose Specification to interpret the file.